### PR TITLE
Fix invisible connection lines in flow view

### DIFF
--- a/media/scenario.js
+++ b/media/scenario.js
@@ -244,7 +244,7 @@
 		diagram.render();
 	}
 
-	jQuery('#event-diagram-content-tab').on('show.bs.tab', buildEventDiagram);
+	jQuery('#event-diagram-content-tab').on('shown.bs.tab', buildEventDiagram);
 	jQuery(filterInput).autoComplete({
 		resolver: 'custom',
 		events: {


### PR DESCRIPTION
The 'show' even is fired before the tab is fully visible. By listening for the 'shown' event, the lines are able to be positioned properly.

Fixes #2 