### PR TITLE
Remove rollup-plugin-terser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4708,34 +4708,6 @@
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
-		"jest-worker": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*",
-				"merge-stream": "^2.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"jquery": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
@@ -5024,12 +4996,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
-		"merge-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"dev": true
 		},
 		"merge2": {
 			"version": "1.4.1",
@@ -7375,29 +7341,6 @@
 				}
 			}
 		},
-		"rollup-plugin-terser": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
-			"integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"jest-worker": "^26.2.1",
-				"serialize-javascript": "^4.0.0",
-				"terser": "^5.0.0"
-			},
-			"dependencies": {
-				"serialize-javascript": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-					"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-					"dev": true,
-					"requires": {
-						"randombytes": "^2.1.0"
-					}
-				}
-			}
-		},
 		"rollup-pluginutils": {
 			"version": "2.8.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
@@ -7803,24 +7746,6 @@
 				"urix": "^0.1.0"
 			}
 		},
-		"source-map-support": {
-			"version": "0.5.19",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-			"dev": true,
-			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -8206,25 +8131,6 @@
 					"requires": {
 						"safe-buffer": "~5.2.0"
 					}
-				}
-			}
-		},
-		"terser": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.5.1.tgz",
-			"integrity": "sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==",
-			"dev": true,
-			"requires": {
-				"commander": "^2.20.0",
-				"source-map": "~0.7.2",
-				"source-map-support": "~0.5.19"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
 		"node-sass": "^5.0.0",
 		"rollup": "^2.35.1",
 		"rollup-plugin-scss": "^2.6.1",
-		"rollup-plugin-terser": "^7.0.2",
 		"rollup-pluginutils": "^2.8.2",
 		"sucrase": "^3.16.0",
 		"tape": "^5.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,3 @@
-import { terser } from 'rollup-plugin-terser';
 import resolve from '@rollup/plugin-node-resolve';
 import scss from 'rollup-plugin-scss';
 import sucrase from '@rollup/plugin-sucrase';
@@ -19,7 +18,6 @@ export default {
     sucrase({
       exclude: ["node_modules/**"],
       transforms: ["typescript"],
-    }),
-    terser(),
+    })
   ],
 };


### PR DESCRIPTION
It causes rollup to produce empty sourcemaps for me. I've spent hours trying to find this problem and then to debug it; in the end
I decided it's not worth the trouble. The extension is still in development, the source code is small and public. We can revisit when needed.