### PR TITLE
Avoid a race when first showing code

### DIFF
--- a/media/scenario.js
+++ b/media/scenario.js
@@ -223,6 +223,8 @@ import FunctionDetails from './ui/functionDetails.js';
 		}
 	});
 
+	vscode.postMessage({ command: 'ready' });
+
 	// Webviews are normally torn down when not visible and re-created when they become visible again.
 	// State lets us save information across these re-loads
 	const state = vscode.getState();


### PR DESCRIPTION
    The extension code tried to send an 'update' message to the webview
    as soon as it finished setting it up; however, the webview might
    not have set its message handler by then. Instead let the webview
    tell the extension when it's ready to avoid the race.