### PR TITLE
Docs: java docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Ruby on Rails, Minitest, RSpec, Cucumber, and more.
 
 The `appmap` Java agent is on GitHub at [https://github.com/applandinc/appmap-java](https://github.com/applandinc/appmap-java).
 
-[View installation instructions for `appmap-java`](https://github.com/applandinc/appmap-java/blob/master/README.md) and a [step-by-step tutorial](https://github.com/applandinc/vscode-appland/blob/master/doc/TUTORIAL-JAVA-PETCLINIC.md).
+For Maven projects, we recommend using the [AppMap Maven plugin](https://github.com/applandinc/appmap-maven-plugin#quickstart), see the [step-by-step tutorial](https://github.com/applandinc/vscode-appland/blob/master/doc/TUTORIAL-JAVA-PETCLINIC.md).
+
+For other than Maven projects, [view installation instructions for `appmap-java`](https://github.com/applandinc/appmap-java/blob/master/README.md).
 
 <a href="https://www.loom.com/share/ccb9f9794f5241f5b6b67579282a288b">
     <p>Visualize the architecture of your Java app, in VS Code, in 2 ¹/₂ minutes - Watch Video</p>
@@ -77,6 +79,14 @@ The `appmap` Java agent is on GitHub at [https://github.com/applandinc/appmap-ja
 **Supported languages and frameworks**
 
 Spring, JUnit, TestNG, and more.
+
+#### Enable searching for AppMap files in the target folder
+
+The Java `appmap` agent saves `.appmap.json` AppMap files in the `target/appmap` folder of the project. This folder is usually included in the `.gitignore` file and excluded from file search in the default Visual Studio Code configuration. To enable searching for AppMap files by their name and extension, update the search settings:
+1. `CTRL|⌘ P`, then type `Preferences: Open Settings (UI)` and pick the matching item from the results
+2. Enter `use ignore` in the search field and unselect the `Search: Use Ignore Files` checkbox
+
+
 
 ## 3. Open an `*.appmap.json` file
 
@@ -136,8 +146,8 @@ The diagrams are fully interactive; they aren’t static pictures like UML. You 
 [App.Land](https://app.land/login) is a free single user sandbox that can be instantly used as an AppMap repository and as a collaboration and sharing tool for your team. 
 
 1. [Sign-up](https://app.land/login) for App.Land, create an account for your organization
-1. [Follow these instructions](https://app.land/setup/cli) to install CLI tools and upload your AppMap files to the App.Land server
-2. Open and share your AppMaps from the App.Land UI. You can make the shareable links public for sharing with other members of your team.
+2. [Follow these instructions](https://app.land/setup/cli) to install CLI tools and upload your AppMap files to the App.Land server
+3. Open and share your AppMaps from the App.Land UI. You can make the shareable links public for sharing with other members of your team.
 
 To share your AppMaps with your team more directly and privately, [contact us](https://appland.com/company/contact-us) about team and enteprise App.Land accounts or go to [AppLand.com](https://appland.com/).
 

--- a/doc/TUTORIAL-JAVA-PETCLINIC.md
+++ b/doc/TUTORIAL-JAVA-PETCLINIC.md
@@ -74,7 +74,7 @@ The AppMap Maven plugin configuration is stored in the `appmap.yml` file in the 
 ```yaml
 name: spring-petclinic
 packages:
-- path: org.springframework.samples.petclinic
+  - path: org.springframework.samples.petclinic
 ```
 The file lists all packages and classes that will be recorded in AppMaps, in this example all code objects in the `org.springframework.samples.petclinic` package.
 

--- a/doc/TUTORIAL-JAVA-PETCLINIC.md
+++ b/doc/TUTORIAL-JAVA-PETCLINIC.md
@@ -30,7 +30,7 @@ The [Spring PetClinic Sample Application project](https://github.com/land-of-app
 Start with a local clone of the `PetClinic` repository. In your working folder, clone the repo:
 
 ```shell
-git clone -b main --single-branch git@github.com:land-of-apps/spring-petclinic.git
+git clone -b main https://github.com/land-of-apps/spring-petclinic.git
 ```
 
 ## Open the PetClinic project in Visual Studio Code
@@ -101,7 +101,7 @@ The AppMap setup is now complete and the application can be recorded when `JUnit
 ./mvnw com.appland:appmap-maven-plugin:prepare-agent test
 ```
 
-The test suite will be run and AppMap files recorded from tests will be created in the `tmp` folder of the project.
+The test suite will be run and AppMap files recorded from tests will be created in the `target/appmap` folder of the project.
 
 ![AppMap files in the tmp folder](https://vscode-appmap.s3.us-east-2.amazonaws.com/media/petclinic-appmaps.png)
 
@@ -110,13 +110,10 @@ Now that you have the AppMaps recorded, let's open them in the Visual Studio Cod
 
 ## Open an AppMap file
 
-1. The recorded AppMap files are in the `tmp` folder of the project.
+1. The recorded AppMap files are in the `target/appmap` folder of the project.
 
-2. Let's open an AppMap that covers showing a pet owner's information.
-Navigate to the `tmp` folder in the file explorer and press  `CTRL|COMMAND P` to find a file by its name
-
-3. Type `ShowOwner` (single word) in the search box and pick the .appmap.json file. An AppMap viewer now opens.
-   
+2. Let's open an AppMap with a good code coverage. Navigate to the `target/appmap` folder in the file explorer
+   and open any of the `.appmap.json` files with the word `Controller` in its name.
 
 ![Show Owner AppMap](https://vscode-appmap.s3.us-east-2.amazonaws.com/media/petclinic-appmap.png)
 


### PR DESCRIPTION
- Adding a direct link to the Maven quickstart instructions
- Updating the instructions for the recent agent change that defaults output to `./target/appmap` .