### PR TITLE
feat: add social links to extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,4 +203,10 @@ Please visit the [AppMap wiki](https://github.com/applandinc/vscode-appland/wiki
 
 # About AppMap
 
-How AppMap technology works: [appland.org](https://appland.org).
+- Learn how AppMap technology works: [appland.org](https://appland.org).
+- [Blog](https://dev.to/appland)
+
+**Twitter**
+- [AppMap Ruby](https://twitter.com/appmapruby)
+- [AppMap Python](https://twitter.com/appmappython)
+- [AppMap Java](https://twitter.com/appmapjava)

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Please visit the [AppMap wiki](https://github.com/applandinc/vscode-appland/wiki
 # About AppMap
 
 - Learn how AppMap technology works: [appland.org](https://appland.org).
-- [Blog](https://appland.com/blog/)
+- [Blog](https://dev.to/appland)
 
 **Twitter**
 - [AppMap Ruby](https://twitter.com/appmapruby)

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Please visit the [AppMap wiki](https://github.com/applandinc/vscode-appland/wiki
 # About AppMap
 
 - Learn how AppMap technology works: [appland.org](https://appland.org).
-- [Blog](https://dev.to/appland)
+- [Blog](https://appland.com/blog/)
 
 **Twitter**
 - [AppMap Ruby](https://twitter.com/appmapruby)


### PR DESCRIPTION
Adds social links to the Extension readme/marketplace
- Dev.to blog
- Twitter for AppMap Ruby, Python & Java accounts
![Screen Shot 2021-03-23 at 3 31 59 PM](https://user-images.githubusercontent.com/123787/112207003-fdb56b80-8bec-11eb-8113-77a3e6c47f12.png)
