### PR TITLE
fix: get/set Appmap state

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,6 +92,33 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       })
     );
 
+    context.subscriptions.push(
+      vscode.window.registerUriHandler({
+        handleUri(uri: vscode.Uri) {
+          if (uri.path === '/open') {
+            const queryParams = new URLSearchParams(uri.query);
+
+            if (queryParams.get('uri')) {
+              vscode.commands.executeCommand(
+                'vscode.open',
+                vscode.Uri.parse(queryParams.get('uri') as string)
+              );
+            }
+
+            if (queryParams.get('state')) {
+              // let's give some time to open AppMap file before setting state
+              setTimeout(() => {
+                vscode.commands.executeCommand(
+                  'appmap.setAppmapStateNoPrompt',
+                  queryParams.get('state')
+                );
+              }, 1000);
+            }
+          }
+        },
+      })
+    );
+
     registerUtilityCommands(context, properties);
 
     vscode.env.onDidChangeTelemetryEnabled((enabled: boolean) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,13 +106,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             }
 
             if (queryParams.get('state')) {
-              // let's give some time to open AppMap file before setting state
-              setTimeout(() => {
-                vscode.commands.executeCommand(
-                  'appmap.setAppmapStateNoPrompt',
-                  queryParams.get('state')
-                );
-              }, 1000);
+              context.globalState.update(ScenarioProvider.INITIAL_STATE, queryParams.get('state'));
             }
           }
         },

--- a/src/scenarioViewer.ts
+++ b/src/scenarioViewer.ts
@@ -43,6 +43,17 @@ export class ScenarioProvider implements vscode.CustomTextEditorProvider {
         }
       })
     );
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand('appmap.setAppmapStateNoPrompt', async (state) => {
+        if (provider.currentWebView) {
+          provider.currentWebView.webview.postMessage({
+            type: 'setAppmapState',
+            state: state,
+          });
+        }
+      })
+    );
   }
 
   private static readonly viewType = 'appmap.views.appMapFile';

--- a/src/scenarioViewer.ts
+++ b/src/scenarioViewer.ts
@@ -60,6 +60,7 @@ export class ScenarioProvider implements vscode.CustomTextEditorProvider {
   private static readonly INSTRUCTIONS_VIEWED = 'APPMAP_INSTRUCTIONS_VIEWED';
   private static readonly RELEASE_KEY = 'APPMAP_RELEASE_KEY';
   public static readonly APPMAP_OPENED = 'APPMAP_OPENED';
+  public static readonly INITIAL_STATE = 'INITIAL_STATE';
   public currentWebView;
 
   constructor(
@@ -103,6 +104,13 @@ export class ScenarioProvider implements vscode.CustomTextEditorProvider {
           version,
         });
       }
+
+      // get initial state and apply to opened webview
+      const initialState = this.context.globalState.get(ScenarioProvider.INITIAL_STATE);
+      if (initialState) {
+        vscode.commands.executeCommand('appmap.setAppmapStateNoPrompt', initialState);
+      }
+      this.context.globalState.update(ScenarioProvider.INITIAL_STATE, null);
     };
 
     // Handle messages from the webview.
@@ -296,5 +304,6 @@ export class ScenarioProvider implements vscode.CustomTextEditorProvider {
     context.globalState.update(ScenarioProvider.INSTRUCTIONS_VIEWED, null);
     context.globalState.update(ScenarioProvider.RELEASE_KEY, null);
     context.globalState.update(ScenarioProvider.APPMAP_OPENED, null);
+    context.globalState.update(ScenarioProvider.INITIAL_STATE, null);
   }
 }


### PR DESCRIPTION
This functionality was added in #169 , but later it was removed because there was a bug with not working `setState` command when few Appmaps were opened.