### PR TITLE
feat: Reset saved usage state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,12 @@ install:
   - yarn
 
 script:
-  - yarn test
+- yarn pretest
+# Setting these two variables get rid of warnings from vscode about
+# being unable to connect to the bus
+- export DBUS_SYSTEM_BUS_ADDRESS='unix:path=/var/run/dbus/system_bus_socket'
+- export DBUS_SESSION_BUS_ADDRESS='unix:path=/var/run/dbus/system_bus_socket'
+- yarn test
 
 deploy:
   - provider: script

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,3 +74,12 @@ their code, delete the appland.appmap.* folders in:
 - Windows: `%USERPROFILE%\.vscode\extensions`
 - Mac: `~/.vscode/extensions`
 - Linux: `~/.vscode/extensions`
+
+## Resetting saved workspace and global states
+
+The extension uses `vscode.ExtensionContext.workspaceState` and `vscode.ExtensionContext.globalState`
+for storage of the state of user's activities. To erase the saved state, run this command in VSCode:
+`AppMap: Reset Usage State`
+
+This command is implemented in `src/utils.ts` `registerUtilityCommands()`. If you are adding new
+stored states, please update this function to reset the new stored states. 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,10 @@
       {
         "command": "appmap.openQuickstart",
         "title": "AppMap: Quickstart"
+      },
+      {
+        "command": "appmap.resetUsageState",
+        "title": "AppMap: Reset Usage State"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,8 @@ import Telemetry, { Events } from './telemetry';
 import registerTrees from './tree';
 import AppMapCollectionFile from './appmapCollectionFile';
 import RemoteRecording from './remoteRecording';
-import { notEmpty } from './util';
+import { getQuickstartSeen, notEmpty, setQuickstartSeen } from './util';
+import { registerUtilityCommands } from './registerUtilityCommands';
 import ProjectWatcher from './projectWatcher';
 import QuickstartWebview from './quickstartWebview';
 
@@ -77,15 +78,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       })
     );
 
-    const storeQuickstartKey = 'APPMAP_QUICKSTART_VIEWED';
-    if (!context.globalState.get(storeQuickstartKey) && projects.length == 1) {
+    registerUtilityCommands(context);
+
+    if (!getQuickstartSeen(context) && projects.length == 1) {
       // only open the quickstart for the first time and a single-project workspace is open
-      context.globalState.update(storeQuickstartKey, true);
       // open the quickstart WebView, step INSTALL_AGENT
       const installAgentMilestone = projects[0].milestones['INSTALL_AGENT'];
       vscode.commands.executeCommand('appmap.clickMilestone', installAgentMilestone);
       // open the quickstart side view
       milestoneTree.reveal(installAgentMilestone, { focus: false });
+      setQuickstartSeen(context, true);
     }
   } catch (exception) {
     Telemetry.sendEvent(Events.DEBUG_EXCEPTION, { exception });

--- a/src/registerUtilityCommands.ts
+++ b/src/registerUtilityCommands.ts
@@ -1,0 +1,17 @@
+import { ScenarioProvider } from './scenarioViewer';
+import * as vscode from 'vscode';
+import { LinkTreeDataProvider } from './tree/linkTreeDataProvider';
+import RemoteRecording from './remoteRecording';
+import { QUICKSTART_SEEN } from './util';
+
+export function registerUtilityCommands(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('appmap.resetUsageState', async () => {
+      context.globalState.update(QUICKSTART_SEEN, null);
+      ScenarioProvider.resetState(context);
+      LinkTreeDataProvider.resetState(context);
+      RemoteRecording.resetState(context);
+      vscode.window.showInformationMessage('AppMap usage state was reset.');
+    })
+  );
+}

--- a/src/remoteRecording.ts
+++ b/src/remoteRecording.ts
@@ -6,7 +6,7 @@ import RemoteRecordingClient from './remoteRecordingClient';
 import { isFileExists } from './util';
 
 export default class RemoteRecording {
-  private static readonly storeRecentRemoteUrlsKey = 'APPMAP_RECENT_REMOTE_URLS';
+  private static readonly RECENT_REMOTE_URLS = 'APPMAP_RECENT_REMOTE_URLS';
   private readonly statusBar: vscode.StatusBarItem;
   private readonly context: vscode.ExtensionContext;
   private activeRecordingUrl: string | null;
@@ -20,7 +20,7 @@ export default class RemoteRecording {
   }
 
   get recentUrls(): string[] {
-    return this.context.workspaceState.get(RemoteRecording.storeRecentRemoteUrlsKey) || [];
+    return this.context.workspaceState.get(RemoteRecording.RECENT_REMOTE_URLS) || [];
   }
 
   addRecentUrl(url: string): void {
@@ -33,10 +33,7 @@ export default class RemoteRecording {
       return;
     }
 
-    this.context.workspaceState.update(RemoteRecording.storeRecentRemoteUrlsKey, [
-      ...recentUrls,
-      url,
-    ]);
+    this.context.workspaceState.update(RemoteRecording.RECENT_REMOTE_URLS, [...recentUrls, url]);
   }
 
   private onBeginRecording(recordingUrl: string): void {
@@ -284,5 +281,9 @@ export default class RemoteRecording {
         await remoteRecording.commandStopCurrent();
       })
     );
+  }
+
+  public static resetState(context: vscode.ExtensionContext): void {
+    context.workspaceState.update(RemoteRecording.RECENT_REMOTE_URLS, null);
   }
 }

--- a/src/scenarioViewer.ts
+++ b/src/scenarioViewer.ts
@@ -23,9 +23,9 @@ export class ScenarioProvider implements vscode.CustomTextEditorProvider {
   }
 
   private static readonly viewType = 'appmap.views.appMapFile';
-  private static readonly storeInstructionsKey = 'APPMAP_INSTRUCTIONS_VIEWED';
-  private static readonly storeReleaseKey = 'APPMAP_RELEASE_KEY';
-  private static readonly storeTelemetryInstallKey = 'APPMAP_TELEMETRY_INSTALL';
+  private static readonly INSTRUCTIONS_VIEWED = 'APPMAP_INSTRUCTIONS_VIEWED';
+  private static readonly RELEASE_KEY = 'APPMAP_RELEASE_KEY';
+  private static readonly TELEMETRY_INSTALL = 'APPMAP_TELEMETRY_INSTALL';
   public static readonly APPMAP_OPENED = 'APPMAP_OPENED';
 
   constructor(private readonly context: vscode.ExtensionContext) {}
@@ -50,14 +50,14 @@ export class ScenarioProvider implements vscode.CustomTextEditorProvider {
       }
 
       // show AppMap instructions on first open
-      if (!this.context.globalState.get(ScenarioProvider.storeInstructionsKey)) {
+      if (!this.context.globalState.get(ScenarioProvider.INSTRUCTIONS_VIEWED)) {
         webviewPanel.webview.postMessage({
           type: 'showInstructions',
         });
-        this.context.globalState.update(ScenarioProvider.storeInstructionsKey, true);
+        this.context.globalState.update(ScenarioProvider.INSTRUCTIONS_VIEWED, true);
       }
 
-      const lastReleaseKey = this.context.globalState.get(ScenarioProvider.storeReleaseKey);
+      const lastReleaseKey = this.context.globalState.get(ScenarioProvider.RELEASE_KEY);
       if (lastReleaseKey !== releaseKey) {
         webviewPanel.webview.postMessage({
           type: 'displayUpdateNotification',
@@ -66,9 +66,9 @@ export class ScenarioProvider implements vscode.CustomTextEditorProvider {
       }
     };
 
-    if (!this.context.globalState.get(ScenarioProvider.storeTelemetryInstallKey)) {
+    if (!this.context.globalState.get(ScenarioProvider.TELEMETRY_INSTALL)) {
       Telemetry.reportAction('install', undefined);
-      this.context.globalState.update(ScenarioProvider.storeTelemetryInstallKey, true);
+      this.context.globalState.update(ScenarioProvider.TELEMETRY_INSTALL, true);
     }
 
     // Handle messages from the webview.
@@ -99,7 +99,7 @@ export class ScenarioProvider implements vscode.CustomTextEditorProvider {
           Telemetry.reportWebviewError(message.error);
           break;
         case 'closeUpdateNotification':
-          this.context.globalState.update(ScenarioProvider.storeReleaseKey, releaseKey);
+          this.context.globalState.update(ScenarioProvider.RELEASE_KEY, releaseKey);
           break;
         case 'appmapOpenUrl':
           vscode.env.openExternal(message.url);
@@ -237,5 +237,12 @@ export class ScenarioProvider implements vscode.CustomTextEditorProvider {
     } catch {
       throw new Error('Could not get document as json. Content is not valid json');
     }
+  }
+
+  //forget usage state set by this class
+  public static resetState(context: vscode.ExtensionContext): void {
+    context.globalState.update(ScenarioProvider.INSTRUCTIONS_VIEWED, null);
+    context.globalState.update(ScenarioProvider.RELEASE_KEY, null);
+    context.globalState.update(ScenarioProvider.APPMAP_OPENED, null);
   }
 }

--- a/src/tree/linkTreeDataProvider.ts
+++ b/src/tree/linkTreeDataProvider.ts
@@ -20,12 +20,14 @@ export class LinkTreeDataProvider implements vscode.TreeDataProvider<vscode.Tree
   public readonly onDidChangeTreeData: vscode.Event<
     vscode.TreeItem | undefined | null | void
   > = this._onDidChangeTreeData.event;
+  private static readonly VISITED_LINKS = 'VISITED_LINKS';
 
   constructor(context: vscode.ExtensionContext, linkDefinitions: LinkDefinitions) {
     this.context = context;
     this.linkDefinitions = { ...linkDefinitions };
 
-    const visitedLinks = (context.globalState.get('VISITED_LINKS') || []) as Array<string>;
+    const visitedLinks = (context.globalState.get(LinkTreeDataProvider.VISITED_LINKS) ||
+      []) as Array<string>;
     visitedLinks.forEach((linkId) => {
       const linkDefinition = this.linkDefinitions[linkId];
       if (linkDefinition) {
@@ -41,10 +43,11 @@ export class LinkTreeDataProvider implements vscode.TreeDataProvider<vscode.Tree
         async (url: vscode.Uri, linkId: string, updateCallback: () => void) => {
           vscode.env.openExternal(url);
 
-          const visitedLinks = (context.globalState.get('VISITED_LINKS') || []) as Array<string>;
+          const visitedLinks = (context.globalState.get(LinkTreeDataProvider.VISITED_LINKS) ||
+            []) as Array<string>;
           if (!visitedLinks.includes(linkId)) {
             visitedLinks.push(linkId);
-            context.globalState.update('VISITED_LINKS', visitedLinks);
+            context.globalState.update(LinkTreeDataProvider.VISITED_LINKS, visitedLinks);
           }
 
           updateCallback();
@@ -58,7 +61,8 @@ export class LinkTreeDataProvider implements vscode.TreeDataProvider<vscode.Tree
   }
 
   public getChildren(): Thenable<vscode.TreeItem[]> {
-    const visitedLinks = (this.context.globalState.get('VISITED_LINKS') || []) as Array<string>;
+    const visitedLinks = (this.context.globalState.get(LinkTreeDataProvider.VISITED_LINKS) ||
+      []) as Array<string>;
 
     const items = Object.entries(this.linkDefinitions).map(([id, item]) => {
       const treeItem = new vscode.TreeItem(item.label);
@@ -85,5 +89,9 @@ export class LinkTreeDataProvider implements vscode.TreeDataProvider<vscode.Tree
 
   private onUpdate() {
     this._onDidChangeTreeData.fire();
+  }
+
+  public static resetState(context: vscode.ExtensionContext): void {
+    context.globalState.update(LinkTreeDataProvider.VISITED_LINKS, null);
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,7 +7,6 @@ import {
   ExecOptions as ProcessExecOptions,
 } from 'child_process';
 import * as vscode from 'vscode';
-import Telemetry, { Events } from './telemetry';
 
 export function getNonce(): string {
   let text = '';
@@ -231,4 +230,15 @@ export async function chainPromises(
     onResolve(await promise);
     return chainPromises(onResolve, ...promises);
   }
+}
+
+export const QUICKSTART_SEEN = 'QUICKSTART_SEEN';
+
+export function getQuickstartSeen(context: vscode.ExtensionContext): boolean {
+  const seen = context.globalState.get(QUICKSTART_SEEN) == true;
+  return seen;
+}
+
+export function setQuickstartSeen(context: vscode.ExtensionContext, seen: boolean): void {
+  context.globalState.update(QUICKSTART_SEEN, seen);
 }

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
-      launchArgs: ['--disable-extensions'],
+      launchArgs: ['--disable-extensions', '--disable-gpu'],
       version: 'insiders',
     });
   } catch (err) {


### PR DESCRIPTION
This update adds a new command "AppMap: Reset usage state" that erases global and workspace states that remember AppMap usage by the user.

Changes:
- `src/util.js`
   - new function `registerUtilityCommands()` that registers the new `appmap.resetUsageState()` command
   - the new command resets all workspace and global states stored by the extension
   -  new `get/setQuickstartSeen` which stores state of the quickstart seen by the user
- `src/extension.ts`
   - calls the new functions in `utils.js`
- `src/remoteRecording.ts, scenarioViewer.rs, linkTreeDataProvider.ts`
   - added `resetState()` to all classes that modify the global or workspace states. This function cleans each class's own mess. Called by `appmap.resetUsageState()` in `src/utils.js`
- `package.json`
   - new command `appmap.resetUsageState`
- `DEVELOPMENT.md`
   - Note about this feature