### PR TITLE
fix: Side view milestones have real links to docs

### DIFF
--- a/src/tree/links.ts
+++ b/src/tree/links.ts
@@ -1,62 +1,47 @@
 export default {
   UsingAppMaps: {
-    USING_APPMAPS_INTERACT_WITH_DIAGRAMS: {
-      label: 'Interact with diagrams',
-      link: 'https://google.com',
+    USING_APPMAPS_HOW_TO_USE_DIAGRAMS: {
+      label: 'How to use AppMap diagrams',
+      link: 'https://appland.com/docs/how-to-use-appmap-diagrams.html',
     },
-    USING_APPMAPS_SETUP_APPMAP_AGENT: {
-      label: 'Setup AppMap agent',
-      link: 'https://google.com',
+    USING_APPMAPS_HOW_TO_READ_SQL_AGENT: {
+      label: 'How to read SQL in AppMaps',
+      link:
+        'https://appland.com/docs/how-to-use-appmap-diagrams.html#how-to-read-sql-code-in-appmaps',
     },
-    USING_APPMAPS_ADD_APPMAPS_TO_CODE_ISSUES: {
-      label: 'Add AppMaps to code issues',
-      link: 'https://google.com',
+    USING_REMOTE_RECORDING: {
+      label: 'Remote recording of AppMaps',
+      link: 'https://appland.com/docs/reference/remote-recording.html',
     },
-    USING_APPMAPS_DEBUG_CODE_USING_APPMAPS: {
-      label: 'Debug code using AppMaps',
-      link: 'https://google.com',
+    USING_REFINING_APPMAPS: {
+      label: 'Refining AppMaps',
+      link: 'https://appland.com/docs/reference/refine-appmaps.html',
     },
-    USING_APPMAPS_SHARE_APPMAPS: {
-      label: 'Share AppMaps',
-      link: 'https://google.com',
+    USING_REFERENCE_GUIDES: {
+      label: 'Reference guides',
+      link: 'https://appland.com/docs/reference/',
     },
-    USING_APPMAPS_UPLOAD_TO_APPMAP_CLOUD: {
-      label: 'Upload to AppMap Cloud',
-      link: 'https://google.com',
+    USING_TROUBLESHOOTING: {
+      label: 'Troubleshooting',
+      link: 'https://appland.com/docs/troubleshooting.html',
     },
   },
   MasteringAppMaps: {
     MASTERING_APPMAPS_ONBOARDING: {
-      label: 'Onboarding',
-      link: 'https://google.com',
+      label: 'Learn how unfamiliar code works',
+      link: 'https://appland.com/docs/guides/learn-how-new-to-you-code-works.html',
     },
-    MASTERING_APPMAPS_SETUP_APPMAP_AGENT: {
-      label: 'Setup AppMap agent',
-      link: 'https://google.com',
+    MASTERING_APPMAP_ADD_TO_CODE_ISSUE: {
+      label: 'Add AppMap to a code issue',
+      link: 'https://appland.com/docs/guides/add-appmaps-to-a-code-issue.html',
     },
-    MASTERING_APPMAPS_AUTO_DOCUMENTING_APIS: {
-      label: 'Auto-documenting APIs',
-      link: 'https://google.com',
+    MASTERING_APPMAPS_DEBUG_CODE: {
+      label: 'Debug code using visual maps',
+      link: 'https://appland.com/docs/guides/debug-code-using-visual-maps.html',
     },
-    MASTERING_APPMAPS_DECONSTRUCTING_MONOLITHS: {
-      label: 'Deconstructing monoliths',
-      link: 'https://google.com',
-    },
-    MASTERING_APPMAPS_REVIEWING_AND_COMMUNICATING: {
-      label: 'Reviewing & communicating designs',
-      link: 'https://google.com',
-    },
-    MASTERING_APPMAPS_ATTACHING_APPMAPS_TO_CODE_TICKETS: {
-      label: 'Attaching AppMaps to code tickets',
-      link: 'https://google.com',
-    },
-    MASTERING_APPMAPS_ACING_CODE_REVIEWS: {
-      label: 'Acing code reviews',
-      link: 'https://google.com',
-    },
-    MASTERING_APPMAPS_DISCOVERING_VULNERABILITIES: {
-      label: 'Discovering vulnerabilities & code debt',
-      link: 'https://google.com',
+    MASTERING_APPMAPS_DEV_TO: {
+      label: 'Read AppMap articles on dev.to',
+      link: 'https://dev.to/appland',
     },
   },
 };


### PR DESCRIPTION
A trivial update - `src/tree/links.ts` was updated with real links to AppMap documentation.