### PR TITLE
fix: Don't coerce arbitrary types into strings

### DIFF
--- a/src/scenarioViewer.ts
+++ b/src/scenarioViewer.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, join } from 'path';
 import * as vscode from 'vscode';
 import { Telemetry, APPMAP_OPEN } from './telemetry';
-import { getNonce, getStringRecords, workspaceFolderForDocument } from './util';
+import { getNonce, getRecords, workspaceFolderForDocument } from './util';
 import { version } from '../package.json';
 import AppMapProperties from './appmapProperties';
 import { AppmapUploader } from './appmapUploader';
@@ -92,7 +92,7 @@ export class ScenarioProvider implements vscode.CustomTextEditorProvider {
         case 'performAction':
           Telemetry.reportAction(
             message.action,
-            getStringRecords(message.data, `appmap.${message.action}`)
+            getRecords(message.data, `appmap.${message.action}`)
           );
           break;
         case 'reportError':

--- a/src/telemetry/telemetryResolver.ts
+++ b/src/telemetry/telemetryResolver.ts
@@ -24,7 +24,7 @@
  * ```
  */
 
-import { getStringRecords } from '../util';
+import { getRecords } from '../util';
 import TelemetryDataProvider from './telemetryDataProvider';
 
 export default class TelemetryResolver<DataType extends Record<string, unknown>> {
@@ -43,9 +43,9 @@ export default class TelemetryResolver<DataType extends Record<string, unknown>>
 
     return entries.reduce((memo, [providerId, resolvedValue]) => {
       if (typeof resolvedValue === 'object') {
-        const flattenedObject = getStringRecords(resolvedValue, providerId);
+        const flattenedObject = getRecords(resolvedValue, providerId);
         Object.entries(flattenedObject).forEach(([key, value]) => {
-          memo[key] = value;
+          memo[key] = value as ValueType;
         });
       } else {
         memo[providerId] = resolvedValue;

--- a/src/telemetry/telemetryResolver.ts
+++ b/src/telemetry/telemetryResolver.ts
@@ -45,7 +45,7 @@ export default class TelemetryResolver<DataType extends Record<string, unknown>>
       if (typeof resolvedValue === 'object') {
         const flattenedObject = getRecords(resolvedValue, providerId);
         Object.entries(flattenedObject).forEach(([key, value]) => {
-          memo[key] = value as ValueType;
+          memo[key] = value;
         });
       } else {
         memo[providerId] = resolvedValue;

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,18 +21,15 @@ export function getNonce(): string {
 // Returns an object's string values with an optional key prefix
 // getStringRecords({ a: 'hello', b: [object Object] }, 'myApp') ->
 // { 'myApp.a': 'hello' }
-export function getStringRecords(
-  obj: Record<string, unknown>,
-  keyPrefix?: string
-): Record<string, string> {
+export function getRecords<T>(obj: Record<string, unknown>, keyPrefix?: string): Record<string, T> {
   const base = keyPrefix ? `${keyPrefix}.` : '';
 
   return Object.entries(obj).reduce((memo, [k, v]) => {
     if (typeof v !== 'object') {
-      memo[`${base}${k}`] = String(v);
+      memo[`${base}${k}`] = v as T;
     }
     return memo;
-  }, {} as Record<string, string>);
+  }, {} as Record<string, T>);
 }
 
 export function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {


### PR DESCRIPTION
This caused an issue when constructing telemetry data where a numeric value was coerced into a string.