### PR TITLE
fix: More robust language detection in project overview

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,8 +40,8 @@ $ yarn run package
    value as the `id` field as the language definition in the `LANGUAGES` array in
    [`src/languageResolver.ts`](src/languageResolver.ts). This creates a link between the agent and
    the language.
-4. Define a version constraint in [`package.json`](package.json) under the `appmapDependencies`
-   property. The agent will not be installed without it.
+4. Make sure there's a corresponding analyzer in [`src/analyzers`](src/analyzers).
+   This implements the quick requirement check for the *Getting started* page.
 
 ## Running in development with a local version of `@appland/components`
 

--- a/src/analyzers/java.ts
+++ b/src/analyzers/java.ts
@@ -1,11 +1,8 @@
-import { RelativePattern, workspace, WorkspaceFolder } from 'vscode';
+import { WorkspaceFolder } from 'vscode';
 import { Features, Result, scoreValue } from '.';
 import { fileWordScanner } from './deps';
 
 export default async function analyze(folder: WorkspaceFolder): Promise<Result | null> {
-  const javafiles = await workspace.findFiles(new RelativePattern(folder, '**/*.java'));
-  if (javafiles.length == 0) return null;
-
   const features: Features = {
     lang: {
       title: 'Java',
@@ -55,7 +52,6 @@ export default async function analyze(folder: WorkspaceFolder): Promise<Result |
 
   return {
     name: folder.name,
-    confidence: javafiles.length,
     features: features,
     score: scoreValue(...Object.entries(features).map(([, t]) => t.score)),
   };

--- a/src/analyzers/python.ts
+++ b/src/analyzers/python.ts
@@ -31,9 +31,6 @@ async function grepFiles(pattern: string, folder: WorkspaceFolder) {
 }
 
 export default async function analyze(folder: WorkspaceFolder): Promise<Result | null> {
-  const pyfiles = await workspace.findFiles(new RelativePattern(folder, '**/__init__.py'));
-  if (pyfiles.length == 0) return null;
-
   const features: Features = {
     lang: {
       title: 'Python',
@@ -96,7 +93,6 @@ export default async function analyze(folder: WorkspaceFolder): Promise<Result |
 
   return {
     name: folder.name,
-    confidence: pyfiles.length,
     features: features,
     score: scoreValue(...Object.entries(features).map(([, t]) => t.score)),
   };

--- a/src/analyzers/ruby.ts
+++ b/src/analyzers/ruby.ts
@@ -1,13 +1,10 @@
-import { RelativePattern, workspace, WorkspaceFolder } from 'vscode';
+import { WorkspaceFolder } from 'vscode';
 import { Features, Result, scoreValue } from '.';
 import { fileWordScanner } from './deps';
 
 const scanGemfile = fileWordScanner('Gemfile');
 
 export default async function analyze(folder: WorkspaceFolder): Promise<Result | null> {
-  const rbfiles = await workspace.findFiles(new RelativePattern(folder, '**/*.rb'));
-  if (rbfiles.length == 0) return null;
-
   const features: Features = {
     lang: {
       title: 'Ruby',
@@ -48,7 +45,6 @@ export default async function analyze(folder: WorkspaceFolder): Promise<Result |
 
   return {
     name: folder.name,
-    confidence: rbfiles.length,
     features: features,
     score: scoreValue(...Object.entries(features).map(([, t]) => t.score)),
   };

--- a/src/analyzers/unknown.ts
+++ b/src/analyzers/unknown.ts
@@ -1,0 +1,15 @@
+import { WorkspaceFolder } from 'vscode';
+import { Result } from '.';
+
+export default function analyze(folder: WorkspaceFolder): Result {
+  return {
+    features: {
+      lang: {
+        score: 'bad',
+        text: `This project looks like it's written in a language not currently supported by AppMap.`,
+      },
+    },
+    name: folder.name,
+    score: 0,
+  };
+}

--- a/src/languageResolver.ts
+++ b/src/languageResolver.ts
@@ -257,27 +257,19 @@ export default class LanguageResolver {
 
   /**
    * Retrieve the most frequently used language id for a given directory. The language returned must be supported (i.e.,
-   * it must be registered in LANGUAGE_AGENTS).
+   * it must be registered in LANGUAGE_AGENTS). If the language is not supported, returns 'unknown'.
    */
   private static async identifyLanguage(rootDirectory: PathLike): Promise<string> {
     const languages = await this.getLanguageDistribution(rootDirectory);
-    let bestFitLanguage = UNKNOWN_LANGUAGE;
-    let maxCount = 0;
-
-    Object.entries(languages).forEach(([lang, count]) => {
-      if (count > maxCount && LANGUAGE_AGENTS[lang]) {
-        bestFitLanguage = lang;
-        maxCount = count;
-      }
-    });
-
-    return bestFitLanguage;
+    const best = Object.entries(languages).sort((a, b) => b[1] - a[1])[0][0];
+    if (LANGUAGE_AGENTS[best]) return best;
+    return UNKNOWN_LANGUAGE;
   }
 
   /**
    * Recursively walk the given `rootDirectory` for known source code files and returns the best-guess SUPPORTED
    * language for the full directory tree. Ignores files and directories that are Git ignored. Results are cached for
-   * each directory for the lifetime of the extension.
+   * each directory for the lifetime of the extension. If the most used language is not supported, returns 'unknown'.
    */
   public static async getLanguage(rootDirectory: PathLike): Promise<string> {
     let language = this.LANGUAGE_CACHE[rootDirectory as string];


### PR DESCRIPTION
- Use LanguageResolver to detect languages.
- Don't pretend a project is some supported language if there's just
  a single script in it among other more common language.