### PR TITLE
feat: Add `Open AppMaps` to updated instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,10 @@
           "type": "boolean",
           "description": "Enable AppMap scanner and findings (preview)"
         },
+        "appMap.instructionsEnabled": {
+          "type": "boolean",
+          "description": "Enable an experimental version of usage instructions"
+        },
         "appMap.inspectEnabled": {
           "type": "boolean",
           "description": "Enable detailed inspection of AppMap code objects (preview)"

--- a/package.json
+++ b/package.json
@@ -362,7 +362,7 @@
     "webpack-cli": "^4.3.1"
   },
   "dependencies": {
-    "@appland/components": "^2.2.0",
+    "@appland/components": "^2.3.0",
     "@appland/diagrams": "^1.5.2",
     "@appland/models": "^1.15.0",
     "@appland/scanner": "^1.57.0",

--- a/src/configuration/extensionSettings.ts
+++ b/src/configuration/extensionSettings.ts
@@ -18,6 +18,11 @@ export default {
       vscode.workspace.getConfiguration('appMap').get('findingsEnabled') || false
     ),
 
+  instructionsEnabled: (): boolean =>
+    [true, 'true'].includes(
+      vscode.workspace.getConfiguration('appMap').get('instructionsEnabled') || false
+    ),
+
   inspectEnabled: (): boolean =>
     [true, 'true'].includes(
       vscode.workspace.getConfiguration('appMap').get('inspectEnabled') || false

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
   try {
     const extensionState = new ExtensionState(context);
+    context.subscriptions.push(extensionState);
+
     if (extensionState.isNewInstall) {
       Telemetry.reportAction('plugin:install');
     }
@@ -151,6 +153,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
         extensionState,
         appmapWatcher,
         configWatcher,
+        appmapCollectionFile,
         findingsIndex
       );
 

--- a/src/services/appmapCollection.ts
+++ b/src/services/appmapCollection.ts
@@ -1,8 +1,9 @@
-import { Event } from 'vscode';
+import { Event, WorkspaceFolder } from 'vscode';
 import AppMapLoader from './appmapLoader';
 
 export default interface AppMapCollection {
   readonly onUpdated: Event<AppMapCollection>;
 
   appMaps(): AppMapLoader[];
+  allAppMapsForWorkspaceFolder(workspaceFolder: WorkspaceFolder): AppMapLoader[];
 }

--- a/src/tree/instructionsTreeDataProvider.ts
+++ b/src/tree/instructionsTreeDataProvider.ts
@@ -40,7 +40,10 @@ const docsPages: DocPage[] = [
     },
     args: ['open-appmaps'],
   },
-  {
+];
+
+if (extensionSettings.findingsEnabled()) {
+  docsPages.push({
     id: 'WALKTHROUGH_INVESTIGATE_FINDINGS',
     title: 'Investigate findings',
     command: 'appmap.openInstallGuide',
@@ -48,10 +51,10 @@ const docsPages: DocPage[] = [
       return Boolean((await projectState.metadata()).analysisPerformed);
     },
     args: ['investigate-findings'],
-  },
-];
+  });
+}
 
-if (!extensionSettings.findingsEnabled()) {
+if (!extensionSettings.instructionsEnabled()) {
   docsPages.splice(0);
   docsPages.push(
     {

--- a/src/tree/instructionsTreeDataProvider.ts
+++ b/src/tree/instructionsTreeDataProvider.ts
@@ -20,7 +20,7 @@ const docsPages: DocPage[] = [
     async isComplete(projectState: ProjectStateServiceInstance): Promise<boolean> {
       return Boolean((await projectState.metadata()).agentInstalled);
     },
-    args: [0],
+    args: ['project-picker'],
   },
   {
     id: 'WALKTHROUGH_RECORD_APPMAPS',
@@ -29,7 +29,16 @@ const docsPages: DocPage[] = [
     async isComplete(projectState: ProjectStateServiceInstance): Promise<boolean> {
       return Boolean((await projectState.metadata()).appMapsRecorded);
     },
-    args: [1],
+    args: ['record-appmaps'],
+  },
+  {
+    id: 'GETTING_STARTED_OPEN_APPMAPS',
+    title: 'Open AppMaps',
+    command: 'appmap.openInstallGuide',
+    async isComplete(projectState: ProjectStateServiceInstance): Promise<boolean> {
+      return Boolean((await projectState.metadata()).appMapOpened);
+    },
+    args: ['open-appmaps'],
   },
   {
     id: 'WALKTHROUGH_INVESTIGATE_FINDINGS',
@@ -38,7 +47,7 @@ const docsPages: DocPage[] = [
     async isComplete(projectState: ProjectStateServiceInstance): Promise<boolean> {
       return Boolean((await projectState.metadata()).analysisPerformed);
     },
-    args: [2],
+    args: ['investigate-findings'],
   },
 ];
 

--- a/src/webviews/installGuideWebview.ts
+++ b/src/webviews/installGuideWebview.ts
@@ -69,6 +69,10 @@ export default class InstallGuideWebView {
 
               break;
 
+            case 'open-file':
+              vscode.commands.executeCommand('vscode.open', vscode.Uri.file(message.file));
+              break;
+
             case 'view-problems':
               vscode.commands.executeCommand('workbench.panel.markers.view.focus');
               break;

--- a/src/webviews/installGuideWebview.ts
+++ b/src/webviews/installGuideWebview.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
+import extensionSettings from '../configuration/extensionSettings';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
 import { getNonce } from '../util';
 import ProjectMetadata from '../workspace/projectMetadata';
@@ -64,6 +65,7 @@ export default class InstallGuideWebView {
               panel.webview.postMessage({
                 type: 'init',
                 projects: await collectProjects(),
+                disabled: extensionSettings.findingsEnabled() ? [] : ['investigate-findings'],
                 page: pageIndex,
               });
 

--- a/src/webviews/openAppmapsWebview.ts
+++ b/src/webviews/openAppmapsWebview.ts
@@ -94,6 +94,10 @@ export default class OpenAppMapsWebview {
               vscode.commands.executeCommand('vscode.open', vscode.Uri.file(message.file));
               break;
 
+            case 'openProjectPicker':
+              vscode.commands.executeCommand('appmap.openWorkspaceOverview');
+              break;
+
             case 'clickLink':
               Telemetry.reportOpenUri(message.uri);
               break;

--- a/src/webviews/projectPickerWebview.ts
+++ b/src/webviews/projectPickerWebview.ts
@@ -99,7 +99,9 @@ async function resultRows(): Promise<string[]> {
 
   const rows: string[] = [];
 
-  const results = (await Promise.all(folders.map(analyze))).sort((a, b) => b.score - a.score);
+  const results = (await Promise.all(folders.map((f) => analyze(f)))).sort(
+    (a, b) => b.score - a.score
+  );
 
   for (const folder of results) {
     const {

--- a/src/workspace/projectMetadata.ts
+++ b/src/workspace/projectMetadata.ts
@@ -1,3 +1,4 @@
+import { AppMapSummary } from '../analyzers';
 import Feature from './feature';
 
 export default interface ProjectMetadata {
@@ -7,8 +8,10 @@ export default interface ProjectMetadata {
   agentInstalled?: boolean;
   appMapsRecorded?: boolean;
   analysisPerformed?: boolean;
+  appMapOpened?: boolean;
   numFindings?: number;
   language?: Feature;
   testFramework?: Feature;
   webFramework?: Feature;
+  appMaps?: Readonly<Array<AppMapSummary>>;
 }

--- a/web/src/installGuideView.js
+++ b/web/src/installGuideView.js
@@ -7,7 +7,7 @@ export default function mountInstallGuide() {
   const vscode = window.acquireVsCodeApi();
   const messages = new MessagePublisher(vscode);
 
-  messages.on('init', ({ projects: startProjects, page: startPage }) => {
+  messages.on('init', ({ projects: startProjects, page: startPage, disabled }) => {
     const app = new Vue({
       el: '#app',
       render(h) {
@@ -15,6 +15,7 @@ export default function mountInstallGuide() {
           ref: 'ui',
           props: {
             projects: this.projects,
+            disabledPages: new Set(disabled),
             editor: 'vscode',
           },
         });

--- a/web/src/installGuideView.js
+++ b/web/src/installGuideView.js
@@ -38,6 +38,14 @@ export default function mountInstallGuide() {
       messages.rpc('view-problems', projectPath);
     });
 
+    app.$on('openAppmap', (file) => {
+      vscode.postMessage({ command: 'open-file', file });
+    });
+
+    app.$on('open-instruction', (pageId) => {
+      app.$refs.ui.jumpTo(pageId);
+    });
+
     messages.on('page', ({ page }) => {
       app.$refs.ui.jumpTo(page);
     });

--- a/web/src/openAppMapsView.js
+++ b/web/src/openAppMapsView.js
@@ -15,7 +15,8 @@ export default function mountQuickstartOpenAppmaps() {
           return h(VOpenAppmaps, {
             ref: 'ui',
             props: {
-              appmaps: this.appmaps,
+              appMaps: this.appmaps,
+              navigationButtons: false,
             },
           });
         },
@@ -35,6 +36,10 @@ export default function mountQuickstartOpenAppmaps() {
 
       app.$on('openAppmap', (file) => {
         vscode.postMessage({ command: 'openFile', file });
+      });
+
+      app.$on('open-instruction', () => {
+        vscode.postMessage({ command: 'openProjectPicker' });
       });
 
       messages.on('appmapSnapshot', ({ appmaps }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,10 +48,10 @@ __metadata:
   linkType: hard
 
 "@appland/appmap@npm:^3.25.4":
-  version: 3.25.4
-  resolution: "@appland/appmap@npm:3.25.4"
+  version: 3.27.3
+  resolution: "@appland/appmap@npm:3.27.3"
   dependencies:
-    "@appland/components": 2.1.0
+    "@appland/components": 2.2.0
     "@appland/diagrams": 1.5.2
     "@appland/models": ^1.14.1
     "@appland/openapi": 1.0.1
@@ -79,14 +79,17 @@ __metadata:
     open: ^8.2.1
     ora: ^5.4.1
     port-pid: ^0.0.7
+    pretty-bytes: ^5.6.0
     ps-node: ^0.1.6
+    read-pkg-up: ^7.0.1
     semver: ^7.3.5
     supports-hyperlinks: ^2.2.0
     w3c-xmlserializer: ^2.0.0
+    write-file-atomic: ^4.0.1
     yargs: ^17.1.1
   bin:
-    appmap: built/src/cli.js
-  checksum: 395dd4ad765f7a333d7390518eb5d846c01f9092400553f6fa205d35ce34e884425cbeef871a7d92ef0379602c677d1b4eb21fdb0c74db2aaf4699acf5c58764
+    appmap: built/cli.js
+  checksum: 24f538b76ab21db998aafa341212b99542eaa448919628532385d5827603b7fdb4676f54167c79b3a102d926b341e241cd1542dced01f7b061f50e95c211c0d7
   languageName: node
   linkType: hard
 
@@ -100,21 +103,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@appland/components@npm:2.1.0"
-  dependencies:
-    "@appland/diagrams": ^1.5.1
-    "@appland/models": ^1.9.0
-    highlight.js: ^10.7.2
-    sql-formatter: ^4.0.2
-    vue: ^2.6.11
-    vuex: ^3.6.0
-  checksum: c7ee3e5d397c659d3b606f6ff8b1a63f66b719adeb500e9b5a242d83cac6506eae12d23e9275e9dc061d9641048de8eb15469db9ab347d72ef031507bd5963be
-  languageName: node
-  linkType: hard
-
-"@appland/components@npm:^2.2.0":
+"@appland/components@npm:2.2.0":
   version: 2.2.0
   resolution: "@appland/components@npm:2.2.0"
   dependencies:
@@ -125,6 +114,20 @@ __metadata:
     vue: ^2.6.11
     vuex: ^3.6.0
   checksum: 9cc94ff4f6dbdec638fbf0559950a349843f72febd69505450b5304df42231296c657531f14bf8941e27f313f601912591b411ab3904881869973fff45f6e7df
+  languageName: node
+  linkType: hard
+
+"@appland/components@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@appland/components@npm:2.3.0"
+  dependencies:
+    "@appland/diagrams": ^1.5.1
+    "@appland/models": ^1.9.0
+    highlight.js: ^10.7.2
+    sql-formatter: ^4.0.2
+    vue: ^2.6.11
+    vuex: ^3.6.0
+  checksum: b748147efbbc87cdbdf7b6072cde201a1da0750be24684ee9100677ebce5aefc3f344e2536d4d45871f6cf6b9b86a666653b7b72752951d75a5f6cc5c1d72a89
   languageName: node
   linkType: hard
 
@@ -163,38 +166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/scanner@npm:^1.56.0":
-  version: 1.56.0
-  resolution: "@appland/scanner@npm:1.56.0"
-  dependencies:
-    "@appland/client": ^1.3.0
-    "@appland/models": ^1.14.5
-    "@appland/sql-parser": ^1.5.0
-    "@types/cli-progress": ^3.9.2
-    ajv: ^8.8.2
-    ansi-escapes: ^5.0.0
-    async: ^3.2.3
-    chalk: ^4.1.2
-    chokidar: ^3.5.3
-    cli-progress: ^3.11.0
-    form-data: ^4.0.0
-    glob: ^7.2.0
-    js-yaml: ^4.1.0
-    lru-cache: ^6.0.0
-    minimatch: ^3.0.4
-    octokat: ^0.10.0
-    openapi-diff: ^0.23.5
-    pretty-format: ^27.4.6
-    supports-hyperlinks: ^2.2.0
-    tar-stream: ^2.2.0
-    yargs: ^17.1.1
-  bin:
-    scanner: built/cli.js
-  checksum: d0190206d425de2795d8b1bd65e10ccfd31a713297efa6f90e20ac7fba5da2a8e965f1588b1f1684ed7be2629b50a7d705e07c317da2122560696aad88ad278e
-  languageName: node
-  linkType: hard
-
-"@appland/scanner@npm:^1.57.0":
+"@appland/scanner@npm:^1.56.0, @appland/scanner@npm:^1.57.0":
   version: 1.57.0
   resolution: "@appland/scanner@npm:1.57.0"
   dependencies:
@@ -3659,7 +3631,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "appmap@workspace:."
   dependencies:
-    "@appland/components": ^2.2.0
+    "@appland/components": ^2.3.0
     "@appland/diagrams": ^1.5.2
     "@appland/models": ^1.15.0
     "@appland/scanner": ^1.57.0
@@ -11807,6 +11779,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"pretty-bytes@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "pretty-bytes@npm:5.6.0"
+  checksum: 9c082500d1e93434b5b291bd651662936b8bd6204ec9fa17d563116a192d6d86b98f6d328526b4e8d783c07d5499e2614a807520249692da9ec81564b2f439cd
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^23.0.1":
   version: 23.6.0
   resolution: "pretty-format@npm:23.6.0"
@@ -13019,6 +12998,13 @@ resolve@^2.0.0-next.3:
   version: 3.0.3
   resolution: "signal-exit@npm:3.0.3"
   checksum: f0169d3f1263d06df32ca072b0bf33b34c6f8f0341a7a1621558a2444dfbe8f5fec76b35537fcc6f0bc4944bdb5336fe0bdcf41a5422c4e45a1dba3f45475e6c
+  languageName: node
+  linkType: hard
+
+"signal-exit@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "signal-exit@npm:3.0.7"
+  checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
   languageName: node
   linkType: hard
 
@@ -15192,6 +15178,16 @@ typescript@^4.1.3:
     signal-exit: ^3.0.2
     typedarray-to-buffer: ^3.1.5
   checksum: c55b24617cc61c3a4379f425fc62a386cc51916a9b9d993f39734d005a09d5a4bb748bc251f1304e7abd71d0a26d339996c275955f527a131b1dcded67878280
+  languageName: node
+  linkType: hard
+
+"write-file-atomic@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "write-file-atomic@npm:4.0.1"
+  dependencies:
+    imurmurhash: ^0.1.4
+    signal-exit: ^3.0.7
+  checksum: 8f780232533ca6223c63c9b9c01c4386ca8c625ebe5017a9ed17d037aec19462ae17109e0aa155bff5966ee4ae7a27b67a99f55caf3f32ffd84155e9da3929fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This change:
- Adds the `Open AppMaps` page back into the instructions list
- Allows listeners to bind to workspace flag updates via `ExtensionState`
- Once published, integrates the changes from https://github.com/applandinc/appmap-js/pull/604