### PR TITLE
feat: Terminal link provider

### DIFF
--- a/src/commands/outOfDateTests.ts
+++ b/src/commands/outOfDateTests.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
 import * as vscode from 'vscode';
 import { AppmapUptodateService, fileLocationsToFilePaths } from '../services/appmapUptodateService';
-import { touch } from '../util';
+import { touch } from '../lib/touch';
 
 const TEST_NAMES = 'File names';
 const TEST_NAMES_LINES = 'File names and line numbers';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ import { ResolvedFinding } from './services/resolvedFinding';
 import AppMapService from './appMapService';
 import LineInfoIndex from './services/lineInfoIndex';
 import registerDecorationProvider from './decorations/decorationProvider';
-import registerHoverProvider from './hover/hoverProvider';
+import appmapHoverProvider from './hover/appmapHoverProvider';
 import registerInspectCodeObject from './commands/inspectCodeObject';
 import openCodeObjectInAppMap from './commands/openCodeObjectInAppMap';
 import ProcessServiceImpl from './processServiceImpl';
@@ -38,6 +38,7 @@ import { AppMapConfigWatcher } from './services/appMapConfigWatcher';
 import ProjectStateService, { ProjectStateServiceInstance } from './services/projectStateService';
 import { AppmapUptodateService } from './services/appmapUptodateService';
 import outOfDateTests from './commands/outOfDateTests';
+import appmapLinkProvider from './terminalLink/appmapLinkProvider';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
   const workspaceServices = new WorkspaceServices(context);
@@ -90,7 +91,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       registerDecorationProvider(context, lineInfoIndex);
       outOfDateTests(context, appmapUptodateService);
       openCodeObjectInAppMap(context, classMapIndex);
-      registerHoverProvider(context, lineInfoIndex);
+      appmapHoverProvider(context, lineInfoIndex);
 
       const classMapWatcher = new ClassMapWatcher({
         onCreate: classMapIndex.addClassMapFile.bind(classMapIndex),
@@ -186,6 +187,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       Telemetry.sendEvent(PROJECT_OPEN, { rootDirectory: workspaceFolder.uri.fsPath });
     });
 
+    appmapLinkProvider();
     AppMapTextEditorProvider.register(context, extensionState);
     RemoteRecording.register(context);
     ContextMenu.register(context);

--- a/src/hover/appmapHoverProvider.ts
+++ b/src/hover/appmapHoverProvider.ts
@@ -3,7 +3,7 @@ import extensionSettings from '../configuration/extensionSettings';
 import { CodeObjectEntry } from '../services/classMapIndex';
 import LineInfoIndex from '../services/lineInfoIndex';
 
-export default function registerHoverProvider(
+export default function appmapHoverProvider(
   context: vscode.ExtensionContext,
   lineInfoIndex: LineInfoIndex
 ): void {

--- a/src/lib/bestFilePath.ts
+++ b/src/lib/bestFilePath.ts
@@ -1,0 +1,46 @@
+import { isAbsolute, join } from 'path';
+import * as vscode from 'vscode';
+
+export async function bestFilePath(
+  path: string,
+  folder?: vscode.WorkspaceFolder,
+  prompt = 'Choose file to open'
+): Promise<vscode.Uri | undefined> {
+  if (isAbsolute(path)) return vscode.Uri.file(path);
+
+  const searchFolders = folder ? [folder] : vscode.workspace.workspaceFolders;
+
+  let pathInFolder: string | undefined;
+  if (searchFolders) {
+    for (let i = 0; !pathInFolder && i < searchFolders.length; ++i) {
+      const folder = searchFolders[i];
+      // findFiles is not tolerant of absolute paths, even if the absolute path matches the
+      // path of the file in the workspace.
+      if (folder.uri.scheme === 'file' && path.startsWith(folder.uri.path)) {
+        pathInFolder = path.slice(folder.uri.path.length + 1);
+      }
+    }
+  }
+
+  const searchPath = join('**', path);
+  return new Promise<vscode.Uri | undefined>((resolve) => {
+    vscode.workspace.findFiles(searchPath).then((uris) => {
+      if (uris.length === 0) {
+        resolve(undefined);
+      } else if (uris.length === 1) {
+        return resolve(uris[0]);
+      } else {
+        const options: vscode.QuickPickOptions = {
+          canPickMany: false,
+          placeHolder: prompt,
+        };
+        vscode.window
+          .showQuickPick(
+            uris.map((uri) => uri.toString()),
+            options
+          )
+          .then((fileName) => resolve(fileName ? vscode.Uri.parse(fileName) : undefined));
+      }
+    });
+  });
+}

--- a/src/lib/touch.ts
+++ b/src/lib/touch.ts
@@ -1,0 +1,16 @@
+import * as fs from 'fs';
+
+export async function touch(path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const time = new Date();
+    fs.utimes(path, time, time, (err) => {
+      if (err) {
+        return fs.open(path, 'w', (err, fd) => {
+          if (err) return reject(err);
+          fs.close(fd, (err) => (err ? reject(err) : resolve()));
+        });
+      }
+      resolve();
+    });
+  });
+}

--- a/src/lib/workspaceFolderForDocument.ts
+++ b/src/lib/workspaceFolderForDocument.ts
@@ -1,0 +1,28 @@
+import * as vscode from 'vscode';
+
+export function workspaceFolderForDocument(
+  document: vscode.TextDocument
+): vscode.WorkspaceFolder | undefined {
+  const { workspaceFolders } = vscode.workspace;
+  if (!workspaceFolders) {
+    return undefined;
+  }
+
+  let bestMatch;
+  let bestMatchLength = 0;
+  workspaceFolders.forEach((workspaceFolder) => {
+    const { length } = workspaceFolder.name;
+    if (bestMatchLength > length) {
+      // The best match matches more characters than this directory has available.
+      // This folder will never be a best match. Skip.
+      return;
+    }
+
+    if (document.uri.fsPath.startsWith(workspaceFolder.uri.fsPath)) {
+      bestMatch = workspaceFolder;
+      bestMatchLength = length;
+    }
+  });
+
+  return bestMatch;
+}

--- a/src/terminalLink/appmapLinkProvider.ts
+++ b/src/terminalLink/appmapLinkProvider.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+import { bestFilePath } from '../lib/bestFilePath';
+
+export class AppMapTerminalLink extends vscode.TerminalLink {
+  constructor(
+    public appMapFileName: string,
+    startIndex: number,
+    length: number,
+    public eventId?: number
+  ) {
+    super(startIndex, length);
+  }
+}
+
+export class AppMapTerminalLinkProvider implements vscode.TerminalLinkProvider {
+  provideTerminalLinks(context: vscode.TerminalLinkContext): vscode.TerminalLink[] {
+    const appmapLocations = context.line.match(/[^\s]+\.appmap\.json(:\d+)?/g);
+    if (!appmapLocations) return [];
+
+    return [...new Set(appmapLocations)].map((match) => {
+      const startIndex = context.line.indexOf(match);
+      const [appMapFileName, eventId] = match.split(':');
+      return new AppMapTerminalLink(
+        appMapFileName,
+        startIndex,
+        match.length,
+        eventId ? Number(eventId) : undefined
+      );
+    });
+  }
+
+  async handleTerminalLink(link: AppMapTerminalLink): Promise<void> {
+    const uri = await bestFilePath(link.appMapFileName);
+    if (!uri) return;
+
+    const state = {
+      currentView: 'viewFlow',
+    } as { currentView: string; selectedObject?: string };
+    if (link.eventId) state.selectedObject = `event:${link.eventId}`;
+    const fragment = JSON.stringify(state);
+    vscode.commands.executeCommand('vscode.open', uri.with({ fragment }));
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function appmapLinkProvider(): void {
+  const provider = new AppMapTerminalLinkProvider();
+  vscode.window.registerTerminalLinkProvider(provider);
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,21 +18,6 @@ export function getNonce(): string {
   return text;
 }
 
-export async function touch(path: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const time = new Date();
-    fs.utimes(path, time, time, (err) => {
-      if (err) {
-        return fs.open(path, 'w', (err, fd) => {
-          if (err) return reject(err);
-          fs.close(fd, (err) => (err ? reject(err) : resolve()));
-        });
-      }
-      resolve();
-    });
-  });
-}
-
 // Returns an object's string values with an optional key prefix
 // getStringRecords({ a: 'hello', b: [object Object] }, 'myApp') ->
 // { 'myApp.a': 'hello' }
@@ -191,33 +176,6 @@ export async function exec(
 
 export function unreachable(msg: string | undefined): never {
   throw new Error(`Unreachable: ${msg}`);
-}
-
-export function workspaceFolderForDocument(
-  document: vscode.TextDocument
-): vscode.WorkspaceFolder | undefined {
-  const { workspaceFolders } = vscode.workspace;
-  if (!workspaceFolders) {
-    return undefined;
-  }
-
-  let bestMatch;
-  let bestMatchLength = 0;
-  workspaceFolders.forEach((workspaceFolder) => {
-    const { length } = workspaceFolder.name;
-    if (bestMatchLength > length) {
-      // The best match matches more characters than this directory has available.
-      // This folder will never be a best match. Skip.
-      return;
-    }
-
-    if (document.uri.fsPath.startsWith(workspaceFolder.uri.fsPath)) {
-      bestMatch = workspaceFolder;
-      bestMatchLength = length;
-    }
-  });
-
-  return bestMatch;
 }
 
 // Resolve promises serially, one at a time.

--- a/test/integration/codeObjects/index.test.ts
+++ b/test/integration/codeObjects/index.test.ts
@@ -3,7 +3,7 @@ import { exists } from 'fs';
 import { join } from 'path';
 import { promisify } from 'util';
 import { CodeObjectEntry } from '../../../src/services/classMapIndex';
-import { touch } from '../../../src/util';
+import { touch } from '../../../src/lib/touch';
 import {
   ExampleAppMap,
   ExampleAppMapIndexDir,

--- a/test/integration/index/updateAsAppMapsAreModified.test.ts
+++ b/test/integration/index/updateAsAppMapsAreModified.test.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { unlink } from 'fs';
 import { promisify } from 'util';
 import * as vscode from 'vscode';
-import { touch } from '../../../src/util';
+import { touch } from '../../../src/lib/touch';
 import { initializeWorkspace, repeatUntil, waitForAppMapServices } from '../util';
 
 describe('AppMapIndex', () => {

--- a/test/integration/terminalLink/terminalLink.test.ts
+++ b/test/integration/terminalLink/terminalLink.test.ts
@@ -1,0 +1,78 @@
+import * as vscode from 'vscode';
+import assert from 'assert';
+import { initializeWorkspace, ProjectA, waitForExtension } from '../util';
+import {
+  AppMapTerminalLink,
+  AppMapTerminalLinkProvider,
+} from '../../../src/terminalLink/appmapLinkProvider';
+import Sinon from 'sinon';
+import { expect } from '@playwright/test';
+import { join, resolve } from 'path';
+
+describe('TerminalLink', () => {
+  beforeEach(initializeWorkspace);
+  beforeEach(waitForExtension);
+  afterEach(initializeWorkspace);
+
+  const firstLink = {
+    startIndex: 22,
+    length: 31,
+    appMapFileName: '/Users/me/proj/test.appmap.json',
+  } as AppMapTerminalLink;
+
+  const secondLink = {
+    startIndex: 66,
+    length: 83,
+    appMapFileName:
+      'tmp/appmap/minitest/Microposts_controller_can_get_microposts_as_JSON.appmap.json',
+    eventId: 12,
+  } as AppMapTerminalLink;
+
+  const line = [
+    'Something happened at',
+    firstLink.appMapFileName,
+    'and also at',
+    [secondLink.appMapFileName, secondLink.eventId].join(':'),
+  ].join(' ');
+
+  it('selects AppMaps from a terminal line', async () => {
+    const linkProvider = new AppMapTerminalLinkProvider();
+    const context = { line, terminal: {} as vscode.Terminal } as vscode.TerminalLinkContext;
+    const links = linkProvider.provideTerminalLinks(context);
+    assert.ok(links);
+    assert.deepStrictEqual(links.length, 2);
+    assert.deepStrictEqual(firstLink, JSON.parse(JSON.stringify(links[0], null, 2)));
+    assert.deepStrictEqual(secondLink, JSON.parse(JSON.stringify(links[1], null, 2)));
+  });
+
+  it('opens an AppMap from a terminal link', async () => {
+    const executeCommand = Sinon.stub(vscode.commands, 'executeCommand').resolves();
+    const linkProvider = new AppMapTerminalLinkProvider();
+
+    await linkProvider.handleTerminalLink(firstLink);
+    await linkProvider.handleTerminalLink(secondLink);
+
+    expect(executeCommand.getCalls()).toHaveLength(2);
+
+    {
+      const call = executeCommand.getCalls()[0];
+      expect(call.args[0]).toEqual('vscode.open');
+      expect(call.args[1].scheme).toEqual('file');
+      expect(call.args[1].path).toEqual(firstLink.appMapFileName);
+      expect(JSON.parse(call.args[1].fragment)).toEqual({
+        currentView: 'viewFlow',
+      });
+    }
+
+    {
+      const call = executeCommand.getCalls()[1];
+      expect(call.args[0]).toEqual('vscode.open');
+      expect(call.args[1].scheme).toEqual('file');
+      expect(call.args[1].path).toEqual(join(ProjectA, secondLink.appMapFileName));
+      expect(JSON.parse(call.args[1].fragment)).toEqual({
+        currentView: 'viewFlow',
+        selectedObject: `event:${secondLink.eventId}`,
+      });
+    }
+  });
+});

--- a/test/integration/uptodate/outOfDate.test.ts
+++ b/test/integration/uptodate/outOfDate.test.ts
@@ -1,7 +1,7 @@
 // @project project-uptodate
 import assert from 'assert';
 import * as vscode from 'vscode';
-import { touch } from '../../../src/util';
+import { touch } from '../../../src/lib/touch';
 import { initializeWorkspace, waitForExtension, waitForIndexer } from '../util';
 import { UserFile, UserPageAppMapFile, waitForDependsUpdate } from './util';
 

--- a/test/integration/uptodate/uptodate.test.ts
+++ b/test/integration/uptodate/uptodate.test.ts
@@ -1,7 +1,7 @@
 // @project project-uptodate
 import assert from 'assert';
 import * as vscode from 'vscode';
-import { touch } from '../../../src/util';
+import { touch } from '../../../src/lib/touch';
 import { initializeWorkspace, waitForExtension, waitForIndexer } from '../util';
 import { UserFile, UserPageAppMapFile, waitForDependsUpdate } from './util';
 

--- a/test/integration/util.ts
+++ b/test/integration/util.ts
@@ -3,7 +3,7 @@ import { exec } from 'child_process';
 import { join } from 'path';
 import assert from 'assert';
 import AppMapService from '../../src/appMapService';
-import { touch } from '../../src/util';
+import { touch } from '../../src/lib/touch';
 
 export const FixtureDir = join(__dirname, '../../../test/fixtures');
 export const ProjectRuby = join(__dirname, '../../../test/fixtures/workspaces/project-ruby');


### PR DESCRIPTION
Scan the VSCode terminal for `*.appmap.json`. Handle Command-Click by opening the corresponding AppMap, including the line number, if available.