### PR TITLE
fix: Create getTreeName function to format tree name

### DIFF
--- a/src/diagnostics/findingsDiagnosticsProvider.ts
+++ b/src/diagnostics/findingsDiagnosticsProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ResolvedFinding } from '../services/resolvedFinding';
+import generateTitle from '../lib/generateDisplayTitle';
 
 type DiagnosticWithProblemLocation = {
   diagnostic: vscode.Diagnostic;
@@ -48,7 +49,7 @@ export default class FindingsDiagnosticsProvider {
       const problemUri = finding.problemLocation.uri;
       updatedProblemUriStrings.add(problemUri.toString());
       const diagnostic = {
-        message: finding.finding.message,
+        message: generateTitle(finding),
         source: 'appmap',
         range: finding.problemLocation.range,
         relatedInformation,

--- a/src/lib/generateDisplayTitle.ts
+++ b/src/lib/generateDisplayTitle.ts
@@ -1,0 +1,20 @@
+import { ResolvedFinding } from '../services/resolvedFinding';
+import * as vscode from 'vscode';
+
+// Gets's name displayed in Findings bar
+export default (finding: ResolvedFinding): string => {
+  const absPath = finding.problemLocation?.uri.path;
+  const relPath = absPath ? vscode.workspace.asRelativePath(absPath) : undefined;
+
+  const rule = finding.finding.ruleTitle;
+  const context = finding.finding.groupMessage || finding.finding.message;
+  const lineno = finding.problemLocation?.range.start.line;
+
+  // If rule and context are the same, only display one
+  const ruleAndContext = rule !== context ? `${rule}: ${context}` : rule;
+
+  // Only display problemLocation if it exists
+  const fullPathString = finding.problemLocation ? `, ${relPath}:${lineno}` : '';
+
+  return `${ruleAndContext}${fullPathString}`;
+};

--- a/src/tree/findingsTreeDataProvider.ts
+++ b/src/tree/findingsTreeDataProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import FindingsIndex from '../services/findingsIndex';
 import { ResolvedFinding } from '../services/resolvedFinding';
+import generateTitle from '../lib/generateDisplayTitle';
 
 export class FindingsTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
   private _onDidChangeTreeData = new vscode.EventEmitter<undefined>();
@@ -31,7 +32,7 @@ export class FindingsTreeDataProvider implements vscode.TreeDataProvider<vscode.
     return Object.values(uniqueFindings)
       .map(
         (finding: ResolvedFinding): vscode.TreeItem => {
-          const item = new vscode.TreeItem(finding.finding.message);
+          const item = new vscode.TreeItem(generateTitle(finding));
           item.id = finding.finding.hash;
           if (finding.problemLocation) {
             item.command = {


### PR DESCRIPTION
[Issue 64](https://github.com/applandinc/board/issues/64)

This PR changes the way items are listed in the Findings menu in VSCode.

New Pattern: `[Rule] in [context], [file:line]`