### PR TITLE
fix: allow analyzer results for python to be returned

### DIFF
--- a/src/services/languageResolver.ts
+++ b/src/services/languageResolver.ts
@@ -280,7 +280,7 @@ export default class LanguageResolver {
 
     const best = Object.entries(languageStats).sort((a, b) => b[1] - a[1])?.[0]?.[0];
     const agent = LANGUAGE_AGENTS[best];
-    if (agent && agent.enabled) return best;
+    if (agent) return best;
     return UNKNOWN_LANGUAGE;
   }
 


### PR DESCRIPTION
Removed the check for `agent.enabled` because it returned `UNKNOWN_LANGUAGE` results for Python instead of the results generated from the analyzer in `python.disabled.ts`.