### PR TITLE
Fix: update scoring in the language analyzers

### DIFF
--- a/src/analyzers/index.ts
+++ b/src/analyzers/index.ts
@@ -5,9 +5,25 @@ import LanguageResolver from '../services/languageResolver';
 
 export type Score = 'bad' | 'ok' | 'good';
 const SCORE_VALUES = { bad: 0, ok: 1, good: 2 };
+const OVERALL_SCORE_VALUES = { bad: 1, ok: 2, good: 3 };
 
 export function scoreValue(...scores: Score[]): number {
   return scores.reduce((s, x) => s + SCORE_VALUES[x], 0);
+}
+
+export function overallScore(result: Features): number {
+  const languageScore: string = result.lang.score;
+  const webFrameworkScore: string = result?.web?.score || 'bad';
+  const testFrameworkScore: string = result?.test?.score || 'bad';
+
+  // score edge cases
+  if (languageScore === 'bad' || webFrameworkScore === 'bad') return OVERALL_SCORE_VALUES['bad'];
+  if (languageScore === 'ok' && webFrameworkScore === 'ok' && testFrameworkScore === 'ok') {
+    return OVERALL_SCORE_VALUES['ok'];
+  }
+
+  // standard scoring
+  return scoreValue(...Object.entries(result).map(([, t]) => t.score));
 }
 
 export type Feature = {

--- a/src/analyzers/java.ts
+++ b/src/analyzers/java.ts
@@ -1,5 +1,5 @@
 import { WorkspaceFolder } from 'vscode';
-import { Features, Result, scoreValue } from '.';
+import { Features, Result, overallScore } from '.';
 import { fileWordScanner } from './deps';
 
 export default async function analyze(folder: WorkspaceFolder): Promise<Result | null> {
@@ -53,6 +53,6 @@ export default async function analyze(folder: WorkspaceFolder): Promise<Result |
   return {
     name: folder.name,
     features: features,
-    score: scoreValue(...Object.entries(features).map(([, t]) => t.score)),
+    score: overallScore(features),
   };
 }

--- a/src/analyzers/javascript.ts
+++ b/src/analyzers/javascript.ts
@@ -1,5 +1,5 @@
 import { Uri, workspace, WorkspaceFolder } from 'vscode';
-import { Features, Result, scoreValue } from '.';
+import { Features, Result, overallScore } from '.';
 import utfDecoder from '../utfDecoder';
 import semverIntersects from 'semver/ranges/intersects';
 
@@ -57,6 +57,6 @@ export default async function analyze(folder: WorkspaceFolder): Promise<Result |
   return {
     name: folder.name,
     features: features,
-    score: scoreValue(...Object.entries(features).map(([, t]) => t.score)),
+    score: overallScore(features),
   };
 }

--- a/src/analyzers/python.ts
+++ b/src/analyzers/python.ts
@@ -1,5 +1,5 @@
 import { RelativePattern, Uri, workspace, WorkspaceFolder } from 'vscode';
-import { Result, scoreValue, Features } from '.';
+import { Result, overallScore, Features } from '.';
 import { fileWordScanner, DependencyFinder } from './deps';
 import utfDecoder from '../utfDecoder';
 const fs = workspace.fs;
@@ -94,6 +94,6 @@ export default async function analyze(folder: WorkspaceFolder): Promise<Result |
   return {
     name: folder.name,
     features: features,
-    score: scoreValue(...Object.entries(features).map(([, t]) => t.score)),
+    score: overallScore(features),
   };
 }

--- a/src/analyzers/ruby.ts
+++ b/src/analyzers/ruby.ts
@@ -1,5 +1,5 @@
 import { WorkspaceFolder } from 'vscode';
-import { Features, Result, scoreValue } from '.';
+import { Features, Result, overallScore } from '.';
 import { fileWordScanner } from './deps';
 
 const scanGemfile = fileWordScanner('Gemfile');
@@ -46,6 +46,6 @@ export default async function analyze(folder: WorkspaceFolder): Promise<Result |
   return {
     name: folder.name,
     features: features,
-    score: scoreValue(...Object.entries(features).map(([, t]) => t.score)),
+    score: overallScore(features),
   };
 }


### PR DESCRIPTION
Fixes: applandinc/board#91

When language, web framework, and test framework are all yellow ('ok') then the project picker says `This project meets all requirements necessary to create AppMaps.` in green.

Before:
![Image](https://user-images.githubusercontent.com/45714532/176326835-4f25daa9-4efd-4dee-afac-d0ba18cb64ce.png)

After:
![image](https://user-images.githubusercontent.com/45714532/176328021-808b8698-ae91-4649-a756-480743a02e47.png)



Also, when there is an unsupported web framework, the project picker says that you can continue:

Before:
![Image](https://user-images.githubusercontent.com/45714532/176327072-3392d229-0fb9-4c86-ba8d-a522992f2a0a.png)

After:
![image](https://user-images.githubusercontent.com/45714532/176328146-85d89afe-3fe4-4508-831a-8e40513ab8bd.png)
