### PR TITLE
Fix: send node status to frontend

### DIFF
--- a/src/analyzers/index.ts
+++ b/src/analyzers/index.ts
@@ -3,7 +3,6 @@ import AppMapCollection from '../services/appmapCollection';
 import AppMapLoader from '../services/appmapLoader';
 import LanguageResolver from '../services/languageResolver';
 import { systemNodeVersion, nvmNodeVersion } from '../services/command';
-// import { resolveFilePath } from '../util';
 
 export type Score = 'bad' | 'ok' | 'good';
 const SCORE_VALUES = { bad: 0, ok: 1, good: 2 };

--- a/src/analyzers/index.ts
+++ b/src/analyzers/index.ts
@@ -97,26 +97,24 @@ export async function analyze(
     result.appMaps = getBestAppMaps(appMaps);
   }
 
-  const nodeVersionString = await getNodeVersion(folder);
-  result.nodeVersion = parseNodeVersion(nodeVersionString);
-
+  result.nodeVersion = await getNodeVersion(folder);
   result.path = folder.uri.fsPath;
 
   return result;
 }
 
-async function getNodeVersion(folder: WorkspaceFolder): Promise<string> {
+async function getNodeVersion(folder: WorkspaceFolder): Promise<NodeVersion> {
   const nvmVersion = await nvmNodeVersion(folder);
   if (nvmVersion) {
-    return nvmVersion;
+    return parseNodeVersion(nvmVersion);
   }
 
   const systemVersion = await systemNodeVersion();
   if (systemVersion instanceof Error) {
-    return '';
+    return parseNodeVersion('');
   }
 
-  return systemVersion;
+  return parseNodeVersion(systemVersion);
 }
 
 function parseNodeVersion(versionString: string): NodeVersion {

--- a/src/analyzers/index.ts
+++ b/src/analyzers/index.ts
@@ -2,6 +2,8 @@ import { WorkspaceFolder } from 'vscode';
 import AppMapCollection from '../services/appmapCollection';
 import AppMapLoader from '../services/appmapLoader';
 import LanguageResolver from '../services/languageResolver';
+import { systemNodeVersion, nvmNodeVersion } from '../services/command';
+// import { resolveFilePath } from '../util';
 
 export type Score = 'bad' | 'ok' | 'good';
 const SCORE_VALUES = { bad: 0, ok: 1, good: 2 };
@@ -51,10 +53,17 @@ export type Result = {
   score: number;
   name: string;
   path?: string;
+  nodeVersion?: NodeVersion;
 };
 
 export type WithAppMaps = {
   appMaps: Readonly<Array<AppMapSummary>>;
+};
+
+export type NodeVersion = {
+  major: number;
+  minor: number;
+  patch: number;
 };
 
 function getBestAppMaps(appMaps: AppMapLoader[], maxCount = 10): AppMapSummary[] {
@@ -89,6 +98,43 @@ export async function analyze(
     result.appMaps = getBestAppMaps(appMaps);
   }
 
+  const nodeVersionString = await getNodeVersion(folder);
+  result.nodeVersion = parseNodeVersion(nodeVersionString);
+
   result.path = folder.uri.fsPath;
+
   return result;
+}
+
+async function getNodeVersion(folder: WorkspaceFolder): Promise<string> {
+  const nvmVersion = await nvmNodeVersion(folder);
+  if (nvmVersion) {
+    return nvmVersion;
+  }
+
+  const systemVersion = await systemNodeVersion();
+  if (systemVersion instanceof Error) {
+    return '';
+  }
+
+  return systemVersion;
+}
+
+function parseNodeVersion(versionString: string): NodeVersion {
+  const digitStrings = versionString.replace(/[^0-9.]/g, '').split('.');
+  const digits = digitStrings.map((digitString) => Number(digitString));
+
+  if (digits.length !== 3) {
+    return {
+      major: 0,
+      minor: 0,
+      patch: 0,
+    };
+  }
+
+  return {
+    major: digits[0],
+    minor: digits[1],
+    patch: digits[2],
+  };
 }

--- a/src/services/projectStateService.ts
+++ b/src/services/projectStateService.ts
@@ -19,7 +19,7 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
 
   public onStateChange = this._onStateChange.event;
 
-  private SUPPORTED_NODE_VERSIONS = [14, 16, 17];
+  private SUPPORTED_NODE_VERSIONS = [14, 16, 18];
 
   constructor(
     public readonly folder: vscode.WorkspaceFolder,

--- a/src/services/projectStateService.ts
+++ b/src/services/projectStateService.ts
@@ -5,7 +5,7 @@ import ExtensionState, { Keys } from '../configuration/extensionState';
 import { FileChangeEmitter } from './fileChangeEmitter';
 import FindingsIndex from './findingsIndex';
 import { ResolvedFinding } from './resolvedFinding';
-import { analyze, scoreValue } from '../analyzers';
+import { analyze, scoreValue, NodeVersion } from '../analyzers';
 import ProjectMetadata from '../workspace/projectMetadata';
 import AppMapCollection from './appmapCollection';
 
@@ -18,6 +18,8 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
   protected numFindings = 0;
 
   public onStateChange = this._onStateChange.event;
+
+  private SUPPORTED_NODE_VERSIONS = [14, 16, 17];
 
   constructor(
     public readonly folder: vscode.WorkspaceFolder,
@@ -151,6 +153,7 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
       name: this.folder.name,
       path: this.folder.uri.fsPath,
       score: analysis.score,
+      hasNode: this.hasNode(analysis.nodeVersion),
       agentInstalled: this.isAgentConfigured || false,
       appMapsRecorded: this.hasRecordedAppMaps || false,
       analysisPerformed: this.analysisPerformed,
@@ -185,6 +188,14 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
 
   dispose(): void {
     this.disposables.forEach((d) => d.dispose());
+  }
+
+  private hasNode(nodeVersion: NodeVersion | undefined): boolean {
+    return !!(
+      nodeVersion &&
+      nodeVersion.major !== 0 &&
+      this.SUPPORTED_NODE_VERSIONS.includes(nodeVersion.major)
+    );
   }
 }
 

--- a/src/workspace/projectMetadata.ts
+++ b/src/workspace/projectMetadata.ts
@@ -5,6 +5,7 @@ export default interface ProjectMetadata {
   name: string;
   path: string;
   score?: number;
+  hasNode: boolean;
   agentInstalled?: boolean;
   appMapsRecorded?: boolean;
   analysisPerformed?: boolean;


### PR DESCRIPTION
Fixes https://github.com/applandinc/board/issues/88

This adds a boolean to the project metadata that signifies if a supported node version was detected. This gets propagated to the frontend so that we can conditionally render a message helping users install the correct version of node.