### PR TITLE
Fix/investigate findings green check

### DIFF
--- a/src/commands/openFinding.ts
+++ b/src/commands/openFinding.ts
@@ -1,0 +1,22 @@
+import * as vscode from 'vscode';
+import ExtensionState from '../configuration/extensionState';
+import { ProjectStateServiceInstance } from '../services/projectStateService';
+import { getWorkspaceFolderFromPath } from '../util';
+
+export default function registerCommand(
+  context: vscode.ExtensionContext,
+  projectStates: ProjectStateServiceInstance[],
+  extensionState: ExtensionState
+): void {
+  const command = vscode.commands.registerCommand('appmap.openFinding', async (uri: vscode.Uri) => {
+    const workspaceFolder = await getWorkspaceFolderFromPath(projectStates, String(uri));
+
+    if (workspaceFolder) {
+      extensionState.setFindingsInvestigated(workspaceFolder, true);
+    }
+
+    vscode.commands.executeCommand('vscode.open', uri);
+  });
+
+  context.subscriptions.push(command);
+}

--- a/src/configuration/extensionState.ts
+++ b/src/configuration/extensionState.ts
@@ -12,6 +12,7 @@ export const Keys = {
     CONFIGURED_AGENT: 'appmap.applandinc.agentConfigured',
     RECORDED_APPMAP: 'appmap.applandinc.recordedAppMap',
     OPENED_APPMAP: 'appmap.applandinc.workspaces_opened_appmap',
+    FINDINGS_INVESTIGATED: 'appmap.applandinc.findingsInvestigated',
   },
 };
 
@@ -137,6 +138,15 @@ export default class ExtensionState {
 
   setWorkspaceConfiguredAgent(workspaceFolder: vscode.WorkspaceFolder, value: boolean): void {
     this.setWorkspaceFlag(Keys.Workspace.CONFIGURED_AGENT, value, workspaceFolder);
+  }
+
+  /** Returns whether or not the user has looked at findings */
+  getFindingsInvestigated(workspaceFolder: vscode.WorkspaceFolder): boolean {
+    return this.getWorkspaceFlag(Keys.Workspace.FINDINGS_INVESTIGATED, workspaceFolder.uri.fsPath);
+  }
+
+  setFindingsInvestigated(workspaceFolder: vscode.WorkspaceFolder, value: boolean): void {
+    this.setWorkspaceFlag(Keys.Workspace.FINDINGS_INVESTIGATED, value, workspaceFolder);
   }
 
   resetState(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import registerTrees from './tree';
 import AppMapCollectionFile from './services/appmapCollectionFile';
 import ContextMenu from './tree/contextMenu';
 import RemoteRecording from './actions/remoteRecording';
-import { notEmpty } from './util';
+import { getWorkspaceFolderFromPath, notEmpty } from './util';
 import { registerUtilityCommands } from './registerUtilityCommands';
 import ExtensionState from './configuration/extensionState';
 import FindingsIndex from './services/findingsIndex';
@@ -41,6 +41,7 @@ import assert from 'assert';
 import { initializeWorkspaceServices } from './services/workspaceServices';
 import { NodeProcessService } from './services/nodeProcessService';
 import getEarlyAccess from './commands/getEarlyAccess';
+import openFinding from './commands/openFinding';
 import { RuntimeAnalysisCtaService } from './services/runtimeAnalysisCtaService';
 
 export async function activate(context: vscode.ExtensionContext): Promise<AppMapService> {
@@ -183,7 +184,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       badge.initialize(projectStates);
       context.subscriptions.push(badge);
 
-      InstallGuideWebView.register(context, projectStates);
+      InstallGuideWebView.register(context, projectStates, extensionState);
       InstallGuideWebView.tryOpen(extensionState);
 
       processService = new NodeProcessService(context, projectStates);
@@ -202,6 +203,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     deleteAllAppMaps(context, classMapIndex, findingsIndex);
 
     registerTrees(context, appmapCollectionFile, projectStates, appmapUptodateService);
+
+    if (findingsEnabled) {
+      openFinding(context, projectStates, extensionState);
+    }
 
     (vscode.workspace.workspaceFolders || []).forEach((workspaceFolder) => {
       Telemetry.sendEvent(PROJECT_OPEN, { rootDirectory: workspaceFolder.uri.fsPath });

--- a/src/services/projectStateService.ts
+++ b/src/services/projectStateService.ts
@@ -52,7 +52,10 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
         }
       }),
       extensionState.onWorkspaceFlag((e) => {
-        if (e.workspaceFolder === folder && e.key === Keys.Workspace.OPENED_APPMAP) {
+        if (
+          e.workspaceFolder === folder &&
+          (e.key === Keys.Workspace.OPENED_APPMAP || e.key === Keys.Workspace.FINDINGS_INVESTIGATED)
+        ) {
           this.updateMetadata();
         }
       })
@@ -80,6 +83,10 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
 
   private get hasOpenedAppMap(): boolean {
     return this.extensionState.getWorkspaceOpenedAppMap(this.folder);
+  }
+
+  private get hasInvestigatedFindings(): boolean {
+    return this.extensionState.getFindingsInvestigated(this.folder);
   }
 
   async metadata(): Promise<Readonly<ProjectMetadata>> {
@@ -166,6 +173,7 @@ export class ProjectStateServiceInstance implements WorkspaceServiceInstance {
       agentInstalled: this.isAgentConfigured || false,
       appMapsRecorded: this.hasRecordedAppMaps || false,
       analysisPerformed: this.analysisPerformed,
+      investigatedFindings: this.hasInvestigatedFindings || false,
       appMapOpened: this.hasOpenedAppMap || false,
       numFindings: this.numFindings,
       language: {

--- a/src/tree/findingsTreeDataProvider.ts
+++ b/src/tree/findingsTreeDataProvider.ts
@@ -37,7 +37,7 @@ export class FindingsTreeDataProvider implements vscode.TreeDataProvider<vscode.
           if (finding.problemLocation) {
             item.command = {
               title: 'Open',
-              command: 'vscode.open',
+              command: 'appmap.openFinding',
               arguments: [finding.problemLocation.uri],
             };
           }

--- a/src/tree/instructionsTreeDataProvider.ts
+++ b/src/tree/instructionsTreeDataProvider.ts
@@ -48,7 +48,7 @@ if (extensionSettings.findingsEnabled()) {
     title: 'Investigate findings',
     command: 'appmap.openInstallGuide',
     async isComplete(projectState: ProjectStateServiceInstance): Promise<boolean> {
-      return Boolean((await projectState.metadata()).analysisPerformed);
+      return Boolean((await projectState.metadata()).investigatedFindings);
     },
     args: ['investigate-findings'],
   });

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,6 +8,7 @@ import {
   ExecOptions as ProcessExecOptions,
 } from 'child_process';
 import * as vscode from 'vscode';
+import { ProjectStateServiceInstance } from './services/projectStateService';
 
 export function getNonce(): string {
   let text = '';
@@ -242,6 +243,26 @@ export function hasPreviouslyInstalledExtension(extensionPath: string): boolean 
   }
 
   return false;
+}
+
+export async function getWorkspaceFolderFromPath(
+  projectStates: ProjectStateServiceInstance[],
+  path: string
+): Promise<vscode.WorkspaceFolder | undefined> {
+  // generate an array of promises that resolve to a project path
+  const promises = projectStates.map(async (projectState) => {
+    const metadata = await projectState.metadata();
+    return metadata?.path;
+  });
+
+  // convert the array of promises to an array of project paths
+  const projectPaths = await Promise.all(promises);
+
+  const projectIndex = projectPaths.findIndex((projectPath) => {
+    return path.includes(projectPath);
+  });
+
+  return projectStates[projectIndex]?.folder;
 }
 
 export function shellescape(...command: string[]): string {

--- a/src/webviews/installGuideWebview.ts
+++ b/src/webviews/installGuideWebview.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import extensionSettings from '../configuration/extensionSettings';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
 import { COPY_COMMAND, OPEN_VIEW, Telemetry } from '../telemetry';
-import { getNonce } from '../util';
+import { getNonce, getWorkspaceFolderFromPath } from '../util';
 import ProjectMetadata from '../workspace/projectMetadata';
 import * as semver from 'semver';
 import ExtensionState from '../configuration/extensionState';
@@ -38,7 +38,8 @@ export default class InstallGuideWebView {
 
   public static register(
     context: vscode.ExtensionContext,
-    projectStates: ProjectStateServiceInstance[]
+    projectStates: ProjectStateServiceInstance[],
+    extensionState: ExtensionState
   ): void {
     context.subscriptions.push(
       vscode.commands.registerCommand(this.command, async (pageIndex: number) => {
@@ -119,9 +120,19 @@ export default class InstallGuideWebView {
               break;
 
             case 'view-problems':
-              vscode.commands.executeCommand('workbench.panel.markers.view.focus');
-              break;
+              {
+                const workspaceFolder = await getWorkspaceFolderFromPath(
+                  projectStates,
+                  message.data
+                );
 
+                if (workspaceFolder) {
+                  extensionState.setFindingsInvestigated(workspaceFolder, true);
+                }
+
+                vscode.commands.executeCommand('workbench.panel.markers.view.focus');
+              }
+              break;
             default:
               break;
           }

--- a/src/workspace/projectMetadata.ts
+++ b/src/workspace/projectMetadata.ts
@@ -9,6 +9,7 @@ export default interface ProjectMetadata {
   agentInstalled?: boolean;
   appMapsRecorded?: boolean;
   analysisPerformed?: boolean;
+  investigatedFindings?: boolean;
   appMapOpened?: boolean;
   numFindings?: number;
   language?: Feature;

--- a/test/system/tests/instructions.test.ts
+++ b/test/system/tests/instructions.test.ts
@@ -40,7 +40,7 @@ describe('Instructions tree view', function() {
     );
     await driver.appMap.assertInstructionStepStatus(
       InstructionStep.InvestigateFindings,
-      InstructionStepStatus.Complete
+      InstructionStepStatus.Pending
     );
 
     await project.simulateAppMapInstall();
@@ -53,6 +53,15 @@ describe('Instructions tree view', function() {
 
     await driver.appMap.assertInstructionStepStatus(
       InstructionStep.RecordAppMaps,
+      InstructionStepStatus.Complete
+    );
+
+    await project.restoreFile('**/appmap-findings.json');
+    await driver.appMap.openInstruction(InstructionStep.InvestigateFindings);
+    await driver.instructionsWebview.clickButton('View problems');
+
+    await driver.appMap.assertInstructionStepStatus(
+      InstructionStep.InvestigateFindings,
       InstructionStepStatus.Complete
     );
 
@@ -108,9 +117,13 @@ describe('Instructions tree view', function() {
   it('hides the pending badge upon completing the installation steps', async () => {
     await driver.appMap.pendingBadge.waitFor({ state: 'visible' });
     await project.simulateAppMapInstall();
-    await project.restoreFile('*.appmap.json');
     await driver.appMap.openActionPanel();
+    await project.restoreFile('*.appmap.json');
     await driver.appMap.openAppMap();
+    await project.restoreFile('**/appmap-findings.json');
+    await driver.appMap.openActionPanel();
+    await driver.appMap.openInstruction(InstructionStep.InvestigateFindings);
+    await driver.instructionsWebview.clickButton('View problems');
     await driver.appMap.pendingBadge.waitFor({ state: 'hidden' });
   });
 
@@ -129,7 +142,7 @@ describe('Instructions tree view', function() {
     );
     await driver.appMap.assertInstructionStepStatus(
       InstructionStep.InvestigateFindings,
-      InstructionStepStatus.Complete
+      InstructionStepStatus.Pending
     );
 
     await driver.appMap.openInstruction(InstructionStep.InstallAppMapAgent);


### PR DESCRIPTION
Fixes applandinc/board#57

The green check mark next to `Investigate findings` now appears when a user presses the 'View problems' button or when a user clicks on a tree item in the `Runtime Analysis` tree view.