### PR TITLE
Feat/explore appmaps instructions page

### DIFF
--- a/package.json
+++ b/package.json
@@ -379,7 +379,7 @@
     "webpack-cli": "^4.3.1"
   },
   "dependencies": {
-    "@appland/components": "^2.6.0",
+    "@appland/components": "^2.9.0",
     "@appland/diagrams": "^1.5.2",
     "@appland/models": "^1.15.0",
     "@appland/scanner": "^1.57.0",

--- a/src/appMapService.ts
+++ b/src/appMapService.ts
@@ -7,6 +7,7 @@ import { AppMapConfigWatcher } from './services/appMapConfigWatcher';
 import { AppmapUptodateService } from './services/appmapUptodateService';
 import Command from './services/command';
 import { NodeProcessService } from './services/nodeProcessService';
+import ProjectStateService from './services/projectStateService';
 import { RuntimeAnalysisCtaService } from './services/runtimeAnalysisCtaService';
 import { SourceFileWatcher } from './services/sourceFileWatcher';
 import { WorkspaceServices } from './services/workspaceServices';
@@ -35,4 +36,5 @@ export default interface AppMapService {
   processService: NodeProcessService;
   extensionState: ExtensionState;
   runtimeAnalysisCta: RuntimeAnalysisCtaService;
+  projectState: ProjectStateService;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,9 +82,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
     const lineInfoIndex = new LineInfoIndex(classMapIndex);
 
     const classMapProvider = new ClassMapTreeDataProvider(classMapIndex);
-    vscode.window.createTreeView('appmap.views.codeObjects', {
+    const codeObjectsTree = vscode.window.createTreeView('appmap.views.codeObjects', {
       treeDataProvider: classMapProvider,
     });
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand('appmap.view.focusCodeObjects', () => {
+        codeObjectsTree.reveal(undefined, { expand: true, focus: true, select: true });
+      })
+    );
 
     const classMapWatcher = new ClassMapWatcher({
       onCreate: classMapIndex.addClassMapFile.bind(classMapIndex),
@@ -173,6 +179,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
         appmapWatcher,
         configWatcher,
         appmapCollectionFile,
+        classMapIndex,
         findingsIndex
       );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,8 +173,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     let processService: NodeProcessService | undefined;
     let runtimeAnalysisCta: RuntimeAnalysisCtaService | undefined;
+    let projectState: ProjectStateService;
     {
-      const projectState = new ProjectStateService(
+      projectState = new ProjectStateService(
         extensionState,
         appmapWatcher,
         configWatcher,
@@ -303,6 +304,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       processService,
       extensionState,
       runtimeAnalysisCta,
+      projectState,
     };
   } catch (exception) {
     Telemetry.sendEvent(DEBUG_EXCEPTION, { exception: exception as Error });

--- a/src/tree/instructionsTreeDataProvider.ts
+++ b/src/tree/instructionsTreeDataProvider.ts
@@ -33,7 +33,7 @@ const docsPages: DocPage[] = [
   },
   {
     id: 'GETTING_STARTED_OPEN_APPMAPS',
-    title: 'Open AppMaps',
+    title: 'Explore AppMaps',
     command: 'appmap.openInstallGuide',
     async isComplete(projectState: ProjectStateServiceInstance): Promise<boolean> {
       return Boolean((await projectState.metadata()).appMapOpened);

--- a/src/webviews/installGuideWebview.ts
+++ b/src/webviews/installGuideWebview.ts
@@ -105,6 +105,9 @@ export default class InstallGuideWebView {
               {
                 const { page, project } = message as PageMessage;
                 Telemetry.sendEvent(OPEN_VIEW, { viewId: page, rootDirectory: project?.path });
+                if (page === 'open-appmaps') {
+                  vscode.commands.executeCommand('appmap.view.focusCodeObjects');
+                }
               }
               break;
 

--- a/src/workspace/projectMetadata.ts
+++ b/src/workspace/projectMetadata.ts
@@ -1,4 +1,5 @@
 import { AppMapSummary } from '../analyzers';
+import { SampleCodeObjects } from '../services/projectStateService';
 import Feature from './feature';
 
 export default interface ProjectMetadata {
@@ -16,4 +17,5 @@ export default interface ProjectMetadata {
   testFramework?: Feature;
   webFramework?: Feature;
   appMaps?: Readonly<Array<AppMapSummary>>;
+  sampleCodeObjects?: SampleCodeObjects;
 }

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -22,6 +22,7 @@ describe('Extension API', () => {
       'processService',
       'extensionState',
       'runtimeAnalysisCta',
+      'projectState',
     ]);
   });
 });

--- a/test/integration/sampleCodeObjects/codeObjects.test.ts
+++ b/test/integration/sampleCodeObjects/codeObjects.test.ts
@@ -1,0 +1,35 @@
+// @project project-a
+import assert from 'assert';
+import { ProjectStateServiceInstance } from '../../../src/services/projectStateService';
+import { initializeWorkspace, waitFor, waitForAppMapServices, waitForExtension } from '../util';
+
+describe('Sample Code Objects', () => {
+  beforeEach(initializeWorkspace);
+  beforeEach(
+    waitForAppMapServices.bind(
+      null,
+      'tmp/appmap/minitest/Microposts_controller_can_get_microposts_as_JSON.appmap.json'
+    )
+  );
+
+  it('are created and added to project metadata', async () => {
+    const appMapService = await waitForAppMapServices(
+      'tmp/appmap/minitest/Microposts_controller_can_get_microposts_as_JSON.appmap.json'
+    );
+
+    await waitFor(`ClassMap not available`, async () => {
+      if (!appMapService.classMap) return false;
+      return (await appMapService.classMap.classMap()).length > 0;
+    });
+
+    const extension = await waitForExtension();
+    const serviceInstance = extension.workspaceServices.getServiceInstances(
+      extension.projectState
+    )[0] as ProjectStateServiceInstance;
+    const sampleCodeObjects = (await serviceInstance.metadata()).sampleCodeObjects;
+
+    assert.notStrictEqual(sampleCodeObjects, undefined, 'not undefined');
+    assert.strictEqual(sampleCodeObjects?.httpRequests.length, 2, 'two HTTP requests');
+    assert.strictEqual(sampleCodeObjects?.queries.length, 5, '5 SQL queries');
+  });
+});

--- a/test/integrationTest.ts
+++ b/test/integrationTest.ts
@@ -35,9 +35,9 @@ async function integrationTest() {
 
   const resolvedTestFiles = fileArgs.map((file) => {
     // Accept file paths relative to the project root or to the test dir.
-    return [(resolve(testDir, file), resolve(projectRootDir, file))].find((fullPath) =>
-      existsSync(fullPath)
-    );
+    return [resolve(testDir, file), resolve(projectRootDir, file)].find((fullPath) => {
+      return existsSync(fullPath);
+    });
   });
   fileArgs.forEach((file, index) => {
     if (!resolvedTestFiles[index]) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,9 +117,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@appland/components@npm:^2.6.0":
-  version: 2.6.0
-  resolution: "@appland/components@npm:2.6.0"
+"@appland/components@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "@appland/components@npm:2.9.0"
   dependencies:
     "@appland/diagrams": ^1.5.1
     "@appland/models": ^1.9.0
@@ -127,7 +127,7 @@ __metadata:
     sql-formatter: ^4.0.2
     vue: ^2.6.11
     vuex: ^3.6.0
-  checksum: 74bf6d43776143005a4c8dc50889aa5ecb0d25d165d32a535cf6eb58d04ea3a5c671dbf61184024683e0e9691a2c6489f6c5ff37ea91daaca0eae52c84b10ead
+  checksum: 4ba4c5fe01b98bd1e28d84fe0cab4ecef4300f475d659c8067815767b199f005382c3a60e862eaa5fe825f3285140bff42c096c7df140fad7c06f58e21b8ea4c
   languageName: node
   linkType: hard
 
@@ -3210,7 +3210,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "appmap@workspace:."
   dependencies:
-    "@appland/components": ^2.6.0
+    "@appland/components": ^2.9.0
     "@appland/diagrams": ^1.5.2
     "@appland/models": ^1.15.0
     "@appland/scanner": ^1.57.0


### PR DESCRIPTION
Fixes applandinc/board#60

Adds selected Code Objects to the `Explore AppMaps` instructions page. Also, the `Code Objects` tree view is highlighted when a user navigates to the `Explore AppMaps` page.