### PR TITLE
feat: Keep viewer state when switching tabs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,15 @@
       }
     },
     {
+      "name": "Run system tests",
+      "type": "node",
+      "request": "launch",
+      "args": ["test/systemTest.ts"],
+      "program": "ts-node",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["run"]
+    },
+    {
       "name": "Extension Tests",
       "type": "extensionHost",
       "request": "launch",

--- a/package.json
+++ b/package.json
@@ -363,6 +363,7 @@
     "openapi-types": "^11.0.1",
     "prettier": "^1.19.1",
     "prettier-eslint": "^12.0.0",
+    "project-root-directory": "^1.0.3",
     "sass": "^1.32.2",
     "sass-loader": "^10.1.0",
     "semantic-release": "^17.3.8",

--- a/src/editor/appmapEditorProvider.ts
+++ b/src/editor/appmapEditorProvider.ts
@@ -21,7 +21,8 @@ export default class AppMapEditorProvider
     const provider = new AppMapEditorProvider(context, extensionState);
     const providerRegistration = vscode.window.registerCustomEditorProvider(
       AppMapEditorProvider.viewType,
-      provider
+      provider,
+      { webviewOptions: { retainContextWhenHidden: true } }
     );
     context.subscriptions.push(providerRegistration);
 

--- a/test/system/src/driver.ts
+++ b/test/system/src/driver.ts
@@ -1,9 +1,17 @@
-import { BrowserContext, ElectronApplication, Page } from '@playwright/test';
+import { BrowserContext, ElectronApplication, Locator, Page } from '@playwright/test';
 import { glob } from 'glob';
 import AppMap from './appMap';
 import InstructionsWebview from './instructionsWebview';
 import Panel from './panel';
 import { getOsShortcut } from './util';
+
+async function tryClick(elem: Locator) {
+  try {
+    await elem.click({ timeout: 5000 });
+  } catch (err) {
+    console.warn(`problem clicking ${elem}: ${err}`);
+  }
+}
 
 export default class Driver {
   public readonly instructionsWebview = new InstructionsWebview(this.page);
@@ -31,15 +39,14 @@ export default class Driver {
   }
 
   public async waitForReady(): Promise<void> {
-    await this.page
-      .locator('[id="status.notifications"] a[role="button"][aria-label="Notifications"]')
-      .click();
-
-    await this.page
-      .locator(
+    await tryClick(
+      this.page.locator('[id="status.notifications"] a[role="button"][aria-label="Notifications"]')
+    );
+    await tryClick(
+      this.page.locator(
         '.notifications-list-container .monaco-list-row:has(span:text("AppMap: Ready")) >> a[role="button"]:text("OK")'
       )
-      .click();
+    );
   }
 
   public async waitForFile(pattern: string): Promise<void> {

--- a/test/system/src/instructionsWebview.ts
+++ b/test/system/src/instructionsWebview.ts
@@ -3,11 +3,13 @@ import { FrameLocator, Locator, Page } from '@playwright/test';
 export default class InstructionsWebview {
   constructor(protected readonly page: Page) {}
 
+  private frameSelector = 'iframe.webview.ready';
+
   private get frame(): FrameLocator {
     return this.page
-      .frameLocator('iframe.webview.ready')
-      .frameLocator('iframe#active-frame')
-      .first();
+      .frameLocator(this.frameSelector)
+      .first()
+      .frameLocator('#active-frame');
   }
 
   public get currentPage(): Locator {
@@ -22,6 +24,12 @@ export default class InstructionsWebview {
   }
 
   public async ready(): Promise<void> {
+    const webviewId = await this.page
+      .locator('[title="Using AppMap"][data-resource-name]')
+      .getAttribute('data-resource-name');
+    if (webviewId) {
+      this.frameSelector = `#${webviewId} iframe`;
+    }
     await this.currentPage.waitFor();
   }
 

--- a/test/systemTest.ts
+++ b/test/systemTest.ts
@@ -5,15 +5,14 @@ import { downloadCode, launchCode } from './system/src/app';
 import Driver from './system/src/driver';
 import ProjectDirectory from './system/tests/support/project';
 import { TestStatus } from './TestStatus';
+import projectRootDirectory from 'project-root-directory';
 
 async function main(): Promise<void> {
   try {
-    const extensionDevelopmentPath = path.resolve(__dirname, '..', '..');
-    const userDataDir = path.resolve(__dirname, '..', '..', '.vscode-test', 'user-data');
+    const extensionDevelopmentPath = projectRootDirectory;
+    const userDataDir = path.resolve(projectRootDirectory, '.vscode-test', 'user-data');
     const projectPath = path.join(
-      __dirname,
-      '..',
-      '..',
+      projectRootDirectory,
       'test',
       'fixtures',
       'workspaces',
@@ -21,7 +20,7 @@ async function main(): Promise<void> {
     );
 
     let verbose = false;
-    let testPath = path.join(__dirname, 'system', 'tests', '**', '*.test.js');
+    let testPath = path.join(__dirname, 'system', 'tests', '**', '*.test.[jt]s');
     const patterns: string[] = [];
     const cliArgs = process.argv.slice(2);
     while (cliArgs.length > 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3268,6 +3268,7 @@ __metadata:
     popper.js: ^1.16.1
     prettier: ^1.19.1
     prettier-eslint: ^12.0.0
+    project-root-directory: ^1.0.3
     sass: ^1.32.2
     sass-loader: ^10.1.0
     semantic-release: ^17.3.8
@@ -10109,6 +10110,15 @@ __metadata:
     "@appland/scanner": ^1.59.0
   languageName: unknown
   linkType: soft
+
+"project-root-directory@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "project-root-directory@npm:1.0.3"
+  dependencies:
+    resolve-from: ^5.0.0
+  checksum: fb9d7414a415cfdc4fe7f478845ab45c092c72be1743bfea3970838f6f38675247f4d857d9dac0b0c8e313fc9064d0c0ddf5053067fe89387569507b947f61d4
+  languageName: node
+  linkType: hard
 
 "project-uptodate@workspace:test/fixtures/workspaces/project-uptodate":
   version: 0.0.0-use.local


### PR DESCRIPTION
One annoying aspect of the editor is that when switching tabs the current context is lost. This fixes this problem.