### PR TITLE
Improve the button shown in the appmaps list when no appmaps have been detected

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 /.yarn/releases/** binary
 /.yarn/plugins/** binary
-
+/extern/yarn.js binary

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
         "icon": "$(extensions-filter)"
       },
       {
-        "command": "appmap.openWorkspaceOverview",
-        "title": "AppMap: Open Instructions View"
+        "command": "appmap.openInstallGuide",
+        "title": "AppMap: Open Install Guide"
       },
       {
         "command": "appmap.view.focusAppMap",
@@ -194,7 +194,7 @@
     "viewsWelcome": [
       {
         "view": "appmap.views.local",
-        "contents": " There are no AppMaps in this project yet.\n[Install AppMap Agent](command:appmap.openInstallGuide?%5B%22project-picker%22%5D)\n",
+        "contents": " There are no AppMaps in this project yet.\n[Get started](command:appmap.openInstallGuide)\n",
         "when": "appmap.initialized && !appmap.hasData"
       },
       {

--- a/package.json
+++ b/package.json
@@ -195,12 +195,7 @@
       {
         "view": "appmap.views.local",
         "contents": " There are no AppMaps in this project yet.\n[Install AppMap Agent](command:appmap.openInstallGuide?%5B%22project-picker%22%5D)\n",
-        "when": "appmap.initialized && !appmap.hasData && config.appMap.instructionsEnabled == true"
-      },
-      {
-        "view": "appmap.views.local",
-        "contents": " There are no AppMaps in this project yet.\n[Getting Started with AppMap](command:appmap.openWorkspaceOverview)\n",
-        "when": "appmap.initialized && !appmap.hasData && config.appMap.instructionsEnabled == false"
+        "when": "appmap.initialized && !appmap.hasData"
       },
       {
         "view": "appmap.views.local",

--- a/package.json
+++ b/package.json
@@ -334,7 +334,7 @@
     "@types/fs-extra": "^9.0.13",
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.0",
-    "@types/node": "^12.19.12",
+    "@types/node": "^14.16.0",
     "@types/semver": "^7.3.9",
     "@types/sinon": "^10.0.2",
     "@types/tmp": "^0.2.3",

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import AppMapCollectionFile from '../services/appmapCollectionFile';
 import Links from './links';
-import { InstructionsTreeDataProvider } from './instructionsTreeDataProvider';
+import { DocsPages, InstructionsTreeDataProvider } from './instructionsTreeDataProvider';
 import { AppMapTreeDataProvider } from './appMapTreeDataProvider';
 import { LinkTreeDataProvider } from './linkTreeDataProvider';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
@@ -43,7 +43,7 @@ export default function registerTrees(
       setTimeout(() => {
         // TODO: (KEG) Here is where we would show the repo state to determine which step should be
         // shown by default.
-        instructionsTree.reveal(instructionsTreeProvider.items[index]);
+        instructionsTree.reveal(DocsPages[index]);
       }, 0);
     })
   );

--- a/src/tree/instructionsTreeDataProvider.ts
+++ b/src/tree/instructionsTreeDataProvider.ts
@@ -3,137 +3,96 @@ import * as path from 'path';
 import svgPending from '../../web/static/media/tree/pending.svg';
 import extensionSettings from '../configuration/extensionSettings';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
+import InstallGuideWebView from '../webviews/installGuideWebview';
 
-interface DocPage {
-  id: string;
-  title: string;
-  command: string;
-  isComplete?: (p: ProjectStateServiceInstance) => Promise<boolean> | boolean;
-  args?: unknown[];
-}
-
-const docsPages: DocPage[] = [
+export const DocsPages = [
   {
-    id: 'WALKTHROUGH_PROJECT_PICKER',
+    id: 'project-picker',
     title: 'Install AppMap agent',
-    command: 'appmap.openInstallGuide',
-    async isComplete(projectState: ProjectStateServiceInstance): Promise<boolean> {
-      return Boolean((await projectState.metadata()).agentInstalled);
-    },
-    args: ['project-picker'],
+    completion: 'agentInstalled',
   },
   {
-    id: 'WALKTHROUGH_RECORD_APPMAPS',
+    id: 'record-appmaps',
     title: 'Record AppMaps',
-    command: 'appmap.openInstallGuide',
-    async isComplete(projectState: ProjectStateServiceInstance): Promise<boolean> {
-      return Boolean((await projectState.metadata()).appMapsRecorded);
-    },
-    args: ['record-appmaps'],
+    completion: 'appMapsRecorded',
   },
   {
-    id: 'GETTING_STARTED_OPEN_APPMAPS',
+    id: 'open-appmaps',
     title: 'Explore AppMaps',
-    command: 'appmap.openInstallGuide',
-    async isComplete(projectState: ProjectStateServiceInstance): Promise<boolean> {
-      return Boolean((await projectState.metadata()).appMapOpened);
-    },
-    args: ['open-appmaps'],
+    completion: 'appMapOpened',
   },
   {
-    id: 'WALKTHROUGH_GENERATE_OPENAPI',
+    id: 'openapi',
     title: 'Generate OpenAPI definitions',
-    command: 'appmap.openInstallGuide',
-    async isComplete(projectState: ProjectStateServiceInstance): Promise<boolean> {
-      return Boolean((await projectState.metadata()).generatedOpenApi);
-    },
-    args: ['openapi'],
+    completion: 'generatedOpenApi',
   },
   {
-    id: 'WALKTHROUGH_INVESTIGATE_FINDINGS',
+    id: 'investigate-findings',
     title: 'Runtime Analysis',
-    command: 'appmap.openInstallGuide',
-    async isComplete(projectState: ProjectStateServiceInstance): Promise<boolean> {
-      return Boolean((await projectState.metadata()).investigatedFindings);
-    },
-    args: ['investigate-findings'],
+    completion: 'investigatedFindings',
   },
-];
+] as const;
 
-async function getIcon(
-  page: DocPage,
-  projectState?: ProjectStateServiceInstance
-): Promise<string | vscode.ThemeIcon> {
-  if (!extensionSettings.findingsEnabled() && page.id === 'WALKTHROUGH_INVESTIGATE_FINDINGS') {
-    return new vscode.ThemeIcon('lock');
-  }
+type DocPage = typeof DocsPages[number];
+export type DocPageId = DocPage['id'];
 
-  if (!projectState || !page.isComplete) {
-    return new vscode.ThemeIcon('circle-large-outline');
-  }
+const icons = {
+  lock: new vscode.ThemeIcon('lock'),
+  unknown: new vscode.ThemeIcon('circle-large-outline'),
+  pending: path.join(__dirname, svgPending),
+  done: new vscode.ThemeIcon('pass-filled', new vscode.ThemeColor('terminal.ansiGreen')),
+};
 
-  return (await page.isComplete(projectState))
-    ? new vscode.ThemeIcon('pass-filled', new vscode.ThemeColor('terminal.ansiGreen'))
-    : path.join(__dirname, svgPending);
-}
-
-export class InstructionsTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
-  private _onDidChangeTreeData: vscode.EventEmitter<
-    vscode.TreeItem | undefined | null | void
-  > = new vscode.EventEmitter<vscode.TreeItem | undefined | null | void>();
-  public readonly onDidChangeTreeData: vscode.Event<
-    vscode.TreeItem | undefined | null | void
-  > = this._onDidChangeTreeData.event;
-  public items: vscode.TreeItem[] = [];
+export class InstructionsTreeDataProvider implements vscode.TreeDataProvider<DocPage> {
+  public onDidChangeTreeData?: vscode.Event<void>;
+  private projectState?: ProjectStateServiceInstance;
+  private completion = new Map<DocPageId, boolean | undefined>();
 
   constructor(
     context: vscode.ExtensionContext,
     protected readonly projectStates: ProjectStateServiceInstance[]
   ) {
-    this.update();
-    if (this.projectState) {
-      context.subscriptions.push(this.projectState.onStateChange(() => this.update()));
+    if (projectStates.length === 1) {
+      [this.projectState] = projectStates;
+      const emitter = new vscode.EventEmitter<void>();
+      context.subscriptions.push(emitter);
+      this.onDidChangeTreeData = emitter.event;
+      this.projectState.onStateChange(() => emitter.fire(), null, context.subscriptions);
     }
   }
 
-  private async update(): Promise<void> {
-    this.items = await this.buildItems();
-    this._onDidChangeTreeData.fire();
+  public getTreeItem({ title, id }: DocPage): vscode.TreeItem {
+    const item = new vscode.TreeItem(title);
+    item.command = {
+      title,
+      command: InstallGuideWebView.command,
+      arguments: [id],
+    };
+    item.iconPath = this.getIcon(id);
+
+    return item;
   }
 
-  private async buildItems(): Promise<vscode.TreeItem[]> {
-    return Promise.all(
-      docsPages.map(async (page) => {
-        const treeItem = new vscode.TreeItem(page.title);
-        treeItem.id = page.id as string;
-        treeItem.command = {
-          command: page.command,
-          arguments: page.args,
-        } as vscode.Command;
+  getIcon(id: DocPageId): string | vscode.ThemeIcon {
+    if (id === 'investigate-findings' && !extensionSettings.findingsEnabled()) return icons.lock;
 
-        treeItem.iconPath = await getIcon(page, this.projectState);
-
-        return treeItem;
-      })
-    );
-  }
-
-  // Return the properties for the current project if only one exists in the workspace
-  private get projectState(): ProjectStateServiceInstance | undefined {
-    if (this.projectStates.length === 1) {
-      return this.projectStates[0];
+    switch (this.completion.get(id)) {
+      case true:
+        return icons.done;
+      case false:
+        return icons.pending;
+      default:
+        return icons.unknown;
     }
   }
 
-  public getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
-    return element;
-  }
+  public async getChildren(): Promise<DocPage[]> {
+    const metadata = await this.projectState?.metadata();
 
-  public getParent(): Thenable<vscode.TreeItem | null> {
-    return Promise.resolve(null);
-  }
+    if (!metadata) this.completion.clear();
+    else
+      this.completion = new Map(DocsPages.map(({ id, completion }) => [id, metadata[completion]]));
 
-  public getChildren(): Thenable<vscode.TreeItem[]> {
-    return Promise.resolve(this.items);
+    return [...DocsPages];
   }
 }

--- a/test/fixtures/workspaces/project-early-access-eligible/.vscode/settings.json
+++ b/test/fixtures/workspaces/project-early-access-eligible/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
   "appMap.findingsEnabled": false,
-  "appMap.instructionsEnabled": true
 }

--- a/test/integration/util.ts
+++ b/test/integration/util.ts
@@ -135,6 +135,11 @@ export async function restoreFile(filePath: string, workspaceDir = ProjectA): Pr
   });
 }
 
+/**
+ * Touches a file, then waits for appmap services to react.
+ * @param touchFile file to touch
+ * @returns current state of services
+ */
 export async function waitForAppMapServices(touchFile: string): Promise<AppMapService> {
   const appMapService = await waitForExtension();
   const wsPath = vscode.workspace.workspaceFolders![0].uri.fsPath;

--- a/test/integration/util.ts
+++ b/test/integration/util.ts
@@ -150,11 +150,6 @@ export async function waitForAppMapServices(touchFile: string): Promise<AppMapSe
     const wsFiles = glob.sync(`${vscode.workspace.workspaceFolders![0].uri.fsPath}/**`);
     console.log(`wsFiles: ${JSON.stringify(wsFiles, null, 2)}`);
     console.log(e);
-    const logs = glob.sync('.vscode-test/user-data/logs/**/?-AppMap Services.log');
-    logs.forEach((f) => {
-      console.log(`${f}:`);
-      console.log(spawnSync('cat', [f]).stdout.toString());
-    });
     throw e;
   }
 

--- a/test/integration/util.ts
+++ b/test/integration/util.ts
@@ -127,12 +127,12 @@ export async function waitForIndexer(): Promise<void> {
 }
 
 export async function restoreFile(filePath: string, workspaceDir = ProjectA): Promise<void> {
-  await withTmpDir(async (tmpDir) => {
-    const tmpPath = join(tmpDir, basename(filePath));
-    const dstPath = join(ProjectA, filePath);
-    await executeWorkspaceOSCommand(`git show HEAD:./${filePath} > ${tmpPath}`, workspaceDir);
-    await fs.rename(tmpPath, dstPath);
-  });
+  // note: git checkout filePath doesn't work here since it doesn't replace the file atomically
+  // which is currently required for the indexer to work correctly
+  const dstPath = join(ProjectA, filePath);
+  const tmpPath = dstPath + '.orig';
+  await executeWorkspaceOSCommand(`git show HEAD:./${filePath} > ${tmpPath}`, workspaceDir);
+  await fs.rename(tmpPath, dstPath);
 }
 
 /**

--- a/test/integrationTest.ts
+++ b/test/integrationTest.ts
@@ -189,10 +189,10 @@ async function integrationTest() {
       if (failFast) break;
     }
   }
-  process.exit(succeeded ? TestStatus.Ok : TestStatus.Failed);
+  process.exitCode = succeeded ? TestStatus.Ok : TestStatus.Failed;
 }
 
 integrationTest().catch((e) => {
   console.warn(e);
-  process.exit(TestStatus.Error);
+  process.exitCode = TestStatus.Error;
 });

--- a/test/integrationTest.ts
+++ b/test/integrationTest.ts
@@ -18,7 +18,7 @@ const PROJECT_UPTODATE = 'test/fixtures/workspaces/project-uptodate';
 const testWorkspaces = [PROJECT_A, PROJECT_UPTODATE];
 const failFast = process.argv.includes('--fail-fast');
 
-const startTime = new Date();
+let startTime = new Date();
 
 async function asyncFilter<T>(
   collection: Iterable<T>,
@@ -121,6 +121,7 @@ async function integrationTest() {
   );
 
   const runTests = async (testFile: string, workspaceDir: string) => {
+    startTime = new Date();
     await runTestsInElectron({
       vscodeExecutablePath,
       extensionDevelopmentPath,

--- a/test/integrationTest.ts
+++ b/test/integrationTest.ts
@@ -15,6 +15,7 @@ import { spawnSync } from 'child_process';
 const PROJECT_A = 'test/fixtures/workspaces/project-a';
 const PROJECT_UPTODATE = 'test/fixtures/workspaces/project-uptodate';
 const testWorkspaces = [PROJECT_A, PROJECT_UPTODATE];
+const failFast = process.argv.includes('--fail-fast');
 
 async function integrationTest() {
   const projectRootDir = resolve(__dirname, '..');
@@ -162,6 +163,7 @@ async function integrationTest() {
         console.log(`${f}:`);
         console.log(spawnSync('cat', [f]).stdout.toString());
       });
+      if (failFast) break;
     }
   }
   process.exit(succeeded ? TestStatus.Ok : TestStatus.Failed);

--- a/test/system/src/app.ts
+++ b/test/system/src/app.ts
@@ -30,7 +30,6 @@ interface LaunchOptions {
 
 export async function downloadCode(): Promise<string> {
   return await downloadAndUnzipVSCode({
-    version: 'insiders',
     reporter: new ConsoleReporter(false),
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2344,10 +2344,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^12.19.12":
-  version: 12.20.19
-  resolution: "@types/node@npm:12.20.19"
-  checksum: 00b623beed4d4b17ad8d60bd2e99a0acab1b95e1d2242d1e2c313abd05a639ecb902c33c5970436d2fd13d5d772747dec6ec73d7f40ad799fe09a35009566699
+"@types/node@npm:^14.16.0":
+  version: 14.18.26
+  resolution: "@types/node@npm:14.18.26"
+  checksum: c6ac3f9d4f6f77c0fa5ac17757779ad4d9835abfe3af5708b7552597cb5c7c1103e83499ccaf767a1cfa70040990bcf3f58761c547051dc8d5077f3c419091b1
   languageName: node
   linkType: hard
 
@@ -3233,7 +3233,7 @@ __metadata:
     "@types/fs-extra": ^9.0.13
     "@types/glob": ^7.1.3
     "@types/mocha": ^8.2.0
-    "@types/node": ^12.19.12
+    "@types/node": ^14.16.0
     "@types/semver": ^7.3.9
     "@types/sinon": ^10.0.2
     "@types/tmp": ^0.2.3


### PR DESCRIPTION
- The button shown didn't actually work since recent changes removed instructions feature flag.
- After fixing that, the button always led to 'install agent' page, even when it was already installed. Now it opens first not done instruction page.

Fixes https://github.com/applandinc/board/issues/87