### PR TITLE
feat: Categorize AppMaps

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Run Extension",
+      "name": "Run extension",
       "type": "extensionHost",
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
@@ -15,7 +15,7 @@
       }
     },
     {
-      "name": "Run system tests",
+      "name": "System tests",
       "type": "node",
       "request": "launch",
       "args": ["test/systemTest.ts"],
@@ -24,11 +24,11 @@
       "runtimeArgs": ["run"]
     },
     {
-      "name": "Extension Tests",
+      "name": "Extension tests",
       "type": "extensionHost",
       "request": "launch",
       "env": {
-        "TEST_FILE": "scanner/performAsAppMapsAreModified.test.js"
+        "TEST_FILE": "appmaps/appmapsTree.test.js"
       },
       "args": [
         "--user-data-dir=${workspaceFolder}/.vscode-test/user-data",

--- a/src/appMapService.ts
+++ b/src/appMapService.ts
@@ -1,3 +1,5 @@
+import * as vscode from 'vscode';
+
 import { AppMapsService } from './appMapsService';
 import { ClassMapService } from './classMapService';
 import ExtensionState from './configuration/extensionState';
@@ -22,6 +24,10 @@ export interface AppMapProcessService {
   invocations: Invocation[];
 }
 
+export type AppMapTreeDataProviders = {
+  appmaps: vscode.TreeDataProvider<vscode.TreeItem>;
+};
+
 export default interface AppMapService {
   editorProvider: AppMapEditorProvider;
   localAppMaps: AppMapsService;
@@ -37,4 +43,5 @@ export default interface AppMapService {
   extensionState: ExtensionState;
   runtimeAnalysisCta: RuntimeAnalysisCtaService;
   projectState: ProjectStateService;
+  trees: AppMapTreeDataProviders;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -215,7 +215,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
 
     deleteAllAppMaps(context, classMapIndex, findingsIndex);
 
-    registerTrees(context, appmapCollectionFile, projectStates, appmapUptodateService);
+    const trees = registerTrees(
+      context,
+      appmapCollectionFile,
+      projectStates,
+      appmapUptodateService
+    );
 
     if (findingsEnabled) {
       openFinding(context, projectStates, extensionState);
@@ -287,6 +292,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<AppMap
       extensionState,
       runtimeAnalysisCta,
       projectState,
+      trees,
     };
   } catch (exception) {
     Telemetry.sendEvent(DEBUG_EXCEPTION, { exception: exception as Error });

--- a/src/services/appmapCollectionFile.ts
+++ b/src/services/appmapCollectionFile.ts
@@ -47,6 +47,7 @@ export default class AppMapCollectionFile implements AppMapCollection, AppMapsSe
   static async collectAppMapDescriptor(uri: vscode.Uri): Promise<AppMapDescriptor | undefined> {
     try {
       const buf = await fs.readFile(uri.fsPath);
+      const timestamp = (await fs.stat(uri.fsPath)).mtimeMs;
       const appmap = JSON.parse(buf.toString());
       let numRequests = 0;
       let numQueries = 0;
@@ -71,7 +72,14 @@ export default class AppMapCollectionFile implements AppMapCollection, AppMapsSe
         (obj.children || []).forEach((child) => stack.push(child));
       }
 
-      return { metadata: appmap.metadata, numRequests, numQueries, numFunctions, resourceUri: uri };
+      return {
+        metadata: appmap.metadata,
+        timestamp: timestamp,
+        numRequests,
+        numQueries,
+        numFunctions,
+        resourceUri: uri,
+      };
     } catch (e) {
       console.error(e);
       console.trace();

--- a/src/services/appmapLoader.ts
+++ b/src/services/appmapLoader.ts
@@ -3,6 +3,7 @@ import { AppMap } from '@appland/models';
 
 export interface AppMapDescriptor {
   resourceUri: vscode.Uri;
+  timestamp: number;
   metadata?: Record<string, unknown>;
   numRequests?: number;
   numQueries?: number;

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -6,13 +6,14 @@ import { AppMapTreeDataProvider } from './appMapTreeDataProvider';
 import { LinkTreeDataProvider } from './linkTreeDataProvider';
 import { ProjectStateServiceInstance } from '../services/projectStateService';
 import { AppmapUptodateService } from '../services/appmapUptodateService';
+import { AppMapTreeDataProviders } from '../appMapService';
 
 export default function registerTrees(
   context: vscode.ExtensionContext,
   localAppMaps: AppMapCollectionFile,
   projectStates: ProjectStateServiceInstance[],
   appmapsUptodate?: AppmapUptodateService
-): Record<string, vscode.TreeView<vscode.TreeItem>> {
+): AppMapTreeDataProviders {
   LinkTreeDataProvider.registerCommands(context);
 
   const instructionsTreeProvider = new InstructionsTreeDataProvider(context, projectStates);
@@ -60,5 +61,5 @@ export default function registerTrees(
     })
   );
 
-  return { localTree: localAppMapsTree, documentationTree };
+  return { appmaps: localAppMapsProvider };
 }

--- a/test/integration/appmaps/appmapsTree.test.ts
+++ b/test/integration/appmaps/appmapsTree.test.ts
@@ -1,0 +1,29 @@
+import assert from 'assert';
+import { initializeWorkspace, waitForExtension } from '../util';
+
+describe('AppMaps', () => {
+  beforeEach(initializeWorkspace);
+  beforeEach(waitForExtension);
+  afterEach(initializeWorkspace);
+
+  it('is a two-level tree', async () => {
+    const trees = (await waitForExtension()).trees;
+
+    const appmapsTree = trees.appmaps;
+    const roots = await appmapsTree.getChildren();
+
+    assert(roots, 'AppMaps tree is empty');
+    assert.deepStrictEqual(roots.map((root) => root.label).sort(), ['minitest']);
+    const minitests = roots[0];
+
+    const appmaps = await appmapsTree.getChildren(minitests);
+    assert(appmaps, `No appmaps for ${minitests.label}`);
+    assert.deepStrictEqual(
+      appmaps.map((appmap) => (appmap as any).descriptor.metadata.name),
+      [
+        'Microposts_controller can get microposts as JSON',
+        'Microposts_interface micropost interface',
+      ]
+    );
+  });
+});

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -23,6 +23,7 @@ describe('Extension API', () => {
       'extensionState',
       'runtimeAnalysisCta',
       'projectState',
+      'trees',
     ]);
   });
 });

--- a/test/system/src/appMap.ts
+++ b/test/system/src/appMap.ts
@@ -50,7 +50,7 @@ export default class AppMap {
   }
 
   public appMapTreeItem(): Locator {
-    return this.appMapTree.locator('.pane-body >> [role="treeitem"]').first();
+    return this.appMapTree.locator('.pane-body >> [role="treeitem"]:not([aria-expanded])').first();
   }
 
   public async expandFindings(): Promise<void> {


### PR DESCRIPTION
AppMaps are organized according to the way they are recorded:

<img width="630" alt="Screen Shot 2022-09-15 at 2 32 16 PM" src="https://user-images.githubusercontent.com/86395/190482540-2b2d3447-82d1-47f5-a980-f938ea5f8bde.png">

"Requests" are sorted by timestamp, other groups are sorted alphabetically. Maybe they should all be sorted by timestamp? But it makes AppMaps of test cases hard to find. I guess it should be configurable.

Full functionality is dependent on the agent conforming to AppMap 1.9.0 - https://github.com/applandinc/appmap/pull/32

